### PR TITLE
feat(prefetch-engine): add Prometheus metrics instrumentation

### DIFF
--- a/prefetch-engine/metrics.py
+++ b/prefetch-engine/metrics.py
@@ -1,0 +1,104 @@
+"""
+Prometheus metrics definitions for the prefetch engine.
+
+Expose via HTTP (pull model) by setting METRICS_PORT (default 8000),
+or push to a Pushgateway by setting METRICS_PUSHGATEWAY_URL.
+"""
+
+import os
+
+from prometheus_client import Counter, Gauge, Histogram, start_http_server, push_to_gateway, REGISTRY
+
+# ── Labels ───────────────────────────────────────────────────────────────────
+_JOB_LABEL = "job_id"
+
+# ── Counters ─────────────────────────────────────────────────────────────────
+files_prefetched_total = Counter(
+    "prefetch_engine_files_prefetched_total",
+    "Number of files successfully copied into the local cache.",
+    [_JOB_LABEL],
+)
+
+files_skipped_total = Counter(
+    "prefetch_engine_files_skipped_total",
+    "Number of candidate files skipped because the source was not found.",
+    [_JOB_LABEL],
+)
+
+cache_hits_total = Counter(
+    "prefetch_engine_cache_hits_total",
+    "Number of ML-job file reads served from the local cache.",
+    [_JOB_LABEL],
+)
+
+cache_misses_total = Counter(
+    "prefetch_engine_cache_misses_total",
+    "Number of ML-job file reads that were not found in the local cache.",
+    [_JOB_LABEL],
+)
+
+minio_uploads_total = Counter(
+    "prefetch_engine_minio_uploads_total",
+    "Number of MinIO upload attempts.",
+    ["status"],  # "success" | "skipped" | "error"
+)
+
+# ── Gauges ───────────────────────────────────────────────────────────────────
+candidates_total = Gauge(
+    "prefetch_engine_candidates_total",
+    "Size of the candidate file pool evaluated in the last selection pass.",
+)
+
+hot_files_selected = Gauge(
+    "prefetch_engine_hot_files_selected",
+    "Number of hot files chosen for prefetch in the last selection pass.",
+)
+
+# ── Histograms ────────────────────────────────────────────────────────────────
+prefetch_duration_seconds = Histogram(
+    "prefetch_engine_prefetch_duration_seconds",
+    "Wall-clock time spent prefetching all hot files for one run.",
+    [_JOB_LABEL],
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)
+
+job_duration_seconds = Histogram(
+    "prefetch_engine_job_duration_seconds",
+    "Wall-clock time spent in the simulated ML job for one run.",
+    [_JOB_LABEL],
+    buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)
+
+minio_upload_duration_seconds = Histogram(
+    "prefetch_engine_minio_upload_duration_seconds",
+    "Wall-clock time spent uploading processed records to MinIO.",
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+)
+
+
+# ── Server helpers ────────────────────────────────────────────────────────────
+
+def start_metrics_server() -> int | None:
+    """
+    Start the Prometheus pull-model HTTP server if METRICS_PORT is set.
+
+    Returns the port number on success, or None if disabled.
+    """
+    raw = os.environ.get("METRICS_PORT", "").strip()
+    if not raw:
+        return None
+    port = int(raw)
+    start_http_server(port)
+    print(f"[METRICS] Prometheus metrics exposed on :{port}/metrics")
+    return port
+
+
+def push_metrics(job_id: str) -> None:
+    """
+    Push metrics to a Prometheus Pushgateway if METRICS_PUSHGATEWAY_URL is set.
+    """
+    url = os.environ.get("METRICS_PUSHGATEWAY_URL", "").strip()
+    if not url:
+        return
+    push_to_gateway(url, job=f"prefetch-engine-{job_id}", registry=REGISTRY)
+    print(f"[METRICS] Pushed metrics to Pushgateway at {url}")

--- a/prefetch-engine/prefetch.py
+++ b/prefetch-engine/prefetch.py
@@ -8,6 +8,8 @@ from io import BytesIO
 from pathlib import Path
 from typing import List
 
+import metrics
+
 
 @dataclass
 class FileStat:
@@ -28,12 +30,22 @@ class FileStat:
 def select_hot_files(candidates: List[FileStat], top_n: int) -> List[FileStat]:
     """Select top-N hot files based on the score."""
     if top_n <= 0:
+        metrics.candidates_total.set(len(candidates))
+        metrics.hot_files_selected.set(0)
         return []
-    # Sort descending by score
-    return sorted(candidates, key=lambda c: c.score, reverse=True)[:top_n]
+    selected = sorted(candidates, key=lambda c: c.score, reverse=True)[:top_n]
+    metrics.candidates_total.set(len(candidates))
+    metrics.hot_files_selected.set(len(selected))
+    return selected
 
 
-def prefetch_files(hot_files: List[FileStat], cache_dir: Path, simulate_latency_s: float = 0.05) -> None:
+def prefetch_files(
+    hot_files: List[FileStat],
+    cache_dir: Path,
+    simulate_latency_s: float = 0.05,
+    *,
+    job_id: str = "unknown",
+) -> None:
     """
     Simulate prefetch by copying local files into a cache directory.
 
@@ -42,20 +54,25 @@ def prefetch_files(hot_files: List[FileStat], cache_dir: Path, simulate_latency_
     cache_dir = Path(cache_dir)
     cache_dir.mkdir(parents=True, exist_ok=True)
 
+    t0 = time.time()
     for f in hot_files:
         src = Path(f.uri.replace("file://", ""))
         dst = cache_dir / src.name
 
         if not src.exists():
             # Skip missing files in the demo; in production this should be logged/alerted.
+            metrics.files_skipped_total.labels(job_id=job_id).inc()
             continue
 
         # Simulate remote IO latency
         time.sleep(simulate_latency_s)
         shutil.copy2(src, dst)
+        metrics.files_prefetched_total.labels(job_id=job_id).inc()
+
+    metrics.prefetch_duration_seconds.labels(job_id=job_id).observe(time.time() - t0)
 
 
-def run_simulated_ml_job(cache_dir: Path, hot_files: List[FileStat]) -> None:
+def run_simulated_ml_job(cache_dir: Path, hot_files: List[FileStat], *, job_id: str = "unknown") -> None:
     """
     Simulate an ML job that consumes prefetched files.
 
@@ -65,6 +82,7 @@ def run_simulated_ml_job(cache_dir: Path, hot_files: List[FileStat]) -> None:
     hits = 0
     misses = 0
 
+    t0 = time.time()
     for f in hot_files:
         src = Path(f.uri.replace("file://", ""))
         cached = cache_dir / src.name
@@ -73,9 +91,11 @@ def run_simulated_ml_job(cache_dir: Path, hot_files: List[FileStat]) -> None:
         else:
             misses += 1
 
-    print(f"[ML JOB] cache hits={hits}, misses={misses}, total={len(hot_files)}")
+    metrics.cache_hits_total.labels(job_id=job_id).inc(hits)
+    metrics.cache_misses_total.labels(job_id=job_id).inc(misses)
+    metrics.job_duration_seconds.labels(job_id=job_id).observe(time.time() - t0)
 
-    # Note: kept as printing only in the original demo.
+    print(f"[ML JOB] cache hits={hits}, misses={misses}, total={len(hot_files)}")
 
 
 @dataclass
@@ -171,6 +191,7 @@ def upload_processed_records_to_minio(records: List[ProcessedRecord]) -> str | N
 
     if not endpoint or not access_key or not secret_key:
         print("[MINIO] Skipping upload (set MINIO_ENDPOINT/MINIO_ACCESS_KEY/MINIO_SECRET_KEY to enable).")
+        metrics.minio_uploads_total.labels(status="skipped").inc()
         return None
 
     try:
@@ -204,6 +225,7 @@ def upload_processed_records_to_minio(records: List[ProcessedRecord]) -> str | N
     data_stream = BytesIO(payload)
     content_type = "application/x-ndjson"
 
+    t0 = time.time()
     client.put_object(
         bucket_name=bucket,
         object_name=object_key,
@@ -211,6 +233,8 @@ def upload_processed_records_to_minio(records: List[ProcessedRecord]) -> str | N
         length=len(payload),
         content_type=content_type,
     )
+    metrics.minio_upload_duration_seconds.observe(time.time() - t0)
+    metrics.minio_uploads_total.labels(status="success").inc()
 
     print(f"[MINIO] Uploaded processed records to bucket={bucket} key={object_key}")
     return object_key
@@ -256,9 +280,12 @@ def main() -> None:
     - prefetch into cache
     - run a simulated ML job
     """
+    metrics.start_metrics_server()
+
     base = Path(os.environ.get("STREAMFORGE_DEMO_DIR", "/tmp/streamforge-demo"))
     manifest_dir = base / "manifest"
     cache_dir = base / "prefetch-cache"
+    job_id = os.environ.get("STREAMFORGE_JOB_ID", _utc_run_id())
 
     print(f"[DEMO] using base directory: {base}")
 
@@ -270,16 +297,16 @@ def main() -> None:
         print(f"  - {f.uri} (recent_access_count={f.recent_access_count})")
 
     print(f"[DEMO] prefetching into cache: {cache_dir}")
-    prefetch_files(hot_files, cache_dir)
+    prefetch_files(hot_files, cache_dir, job_id=job_id)
 
     print("[DEMO] running simulated ML job")
-    job_id = os.environ.get("STREAMFORGE_JOB_ID", _utc_run_id())
-    # Keep the original cache hit/miss reporting.
-    run_simulated_ml_job(cache_dir, hot_files)
+    run_simulated_ml_job(cache_dir, hot_files, job_id=job_id)
 
     # Build and upload processed outputs (NDJSON).
     records = build_processed_records(job_id=job_id, cache_dir=cache_dir, hot_files=hot_files)
     upload_processed_records_to_minio(records)
+
+    metrics.push_metrics(job_id)
 
 
 if __name__ == "__main__":

--- a/prefetch-engine/requirements.txt
+++ b/prefetch-engine/requirements.txt
@@ -1,1 +1,2 @@
 minio
+prometheus_client>=0.20


### PR DESCRIPTION
Adds prometheus_client-based observability to the prefetch engine:
- metrics.py: central registry with counters, gauges, and histograms covering file selection, prefetch throughput, ML job cache hit rate, and MinIO upload latency/status
- prefetch.py: instrument select_hot_files, prefetch_files, run_simulated_ml_job, and upload_processed_records_to_minio
- All metrics carry a job_id label for per-run slicing
- Pull model: set METRICS_PORT to expose /metrics HTTP endpoint
- Push model: set METRICS_PUSHGATEWAY_URL to push after each run
- requirements.txt: add prometheus_client>=0.20