### PR TITLE
feat(stream-processor): add optional Apache Iceberg sink connector

### DIFF
--- a/stream-processor/pom.xml
+++ b/stream-processor/pom.xml
@@ -16,6 +16,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <flink.version>1.18.1</flink.version>
+        <iceberg.version>1.5.2</iceberg.version>
+        <hadoop.version>3.3.4</hadoop.version>
         <jackson.version>2.17.2</jackson.version>
         <junit.version>5.10.2</junit.version>
     </properties>
@@ -58,6 +60,40 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
+        </dependency>
+
+        <!-- Iceberg Flink sink (optional at runtime; enable with ICEBERG_ENABLED=true) -->
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-flink-runtime-1.18</artifactId>
+            <version>${iceberg.version}</version>
+        </dependency>
+        <!-- Flink Table API types (RowData, GenericRowData, StringData) — on the cluster -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Hadoop filesystem support: Iceberg HadoopCatalog + S3A for MinIO -->
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>provided</scope>
+            <exclusions>
+                <exclusion><groupId>log4j</groupId><artifactId>log4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-log4j12</artifactId></exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-aws</artifactId>
+            <version>${hadoop.version}</version>
+            <exclusions>
+                <exclusion><groupId>log4j</groupId><artifactId>log4j</artifactId></exclusion>
+                <exclusion><groupId>org.slf4j</groupId><artifactId>slf4j-log4j12</artifactId></exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Logging — provided by the Flink cluster at runtime -->
@@ -105,6 +141,16 @@
                         </goals>
                         <configuration>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/LICENSE*</exclude>
+                                        <exclude>META-INF/NOTICE*</exclude>
+                                        <exclude>META-INF/DEPENDENCIES</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>ai.streamforge.processor.CdcUserEventCountJob</mainClass>

--- a/stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java
@@ -4,6 +4,7 @@ import ai.streamforge.processor.deserialization.CdcEventDeserializationSchema;
 import ai.streamforge.processor.model.CdcEvent;
 import ai.streamforge.processor.model.UserEventCount;
 import ai.streamforge.processor.serialization.UserEventCountSerializationSchema;
+import ai.streamforge.processor.sink.IcebergSinkFactory;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
 import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
@@ -37,6 +38,18 @@ import java.time.Duration;
  *   <li>{@code KAFKA_CONSUMER_GROUP}     — default {@code flink-cdc-user-event-count}</li>
  *   <li>{@code WINDOW_SIZE_SECONDS}      — default {@code 60}</li>
  *   <li>{@code OUT_OF_ORDERNESS_SECONDS} — default {@code 5}</li>
+ * </ul>
+ *
+ * <p>Optional Apache Iceberg sink (set {@code ICEBERG_ENABLED=true} to activate):
+ * <ul>
+ *   <li>{@code ICEBERG_ENABLED}       — default {@code false}</li>
+ *   <li>{@code ICEBERG_CATALOG_TYPE}  — {@code hadoop} (default), {@code hive}, or {@code rest}</li>
+ *   <li>{@code ICEBERG_WAREHOUSE}     — default {@code file:///tmp/iceberg-warehouse}</li>
+ *   <li>{@code ICEBERG_DATABASE}      — default {@code streamforge}</li>
+ *   <li>{@code ICEBERG_TABLE}         — default {@code user_event_counts}</li>
+ *   <li>{@code ICEBERG_S3_ENDPOINT}   — S3/MinIO endpoint, e.g. {@code http://minio:9000}</li>
+ *   <li>{@code ICEBERG_S3_ACCESS_KEY} — S3/MinIO access key</li>
+ *   <li>{@code ICEBERG_S3_SECRET_KEY} — S3/MinIO secret key</li>
  * </ul>
  */
 public class CdcUserEventCountJob {
@@ -94,6 +107,22 @@ public class CdcUserEventCountJob {
                 .build();
 
         counts.sinkTo(sink).name("Kafka Sink: " + sinkTopic);
+
+        // ── Optional Iceberg sink ────────────────────────────────────────────
+        if (Boolean.parseBoolean(env("ICEBERG_ENABLED", "false"))) {
+            String catalogType  = env("ICEBERG_CATALOG_TYPE",  "hadoop");
+            String warehouse    = env("ICEBERG_WAREHOUSE",     "file:///tmp/iceberg-warehouse");
+            String database     = env("ICEBERG_DATABASE",      "streamforge");
+            String icebergTable = env("ICEBERG_TABLE",         "user_event_counts");
+            String s3Endpoint   = env("ICEBERG_S3_ENDPOINT",   "");
+            String s3AccessKey  = env("ICEBERG_S3_ACCESS_KEY", "");
+            String s3SecretKey  = env("ICEBERG_S3_SECRET_KEY", "");
+
+            LOG.info("Iceberg sink enabled: catalog={}, warehouse={}, table={}.{}",
+                    catalogType, warehouse, database, icebergTable);
+            IcebergSinkFactory.attach(counts, catalogType, warehouse, database, icebergTable,
+                    s3Endpoint, s3AccessKey, s3SecretKey);
+        }
 
         env.execute("CdcUserEventCountJob");
     }

--- a/stream-processor/src/main/java/ai/streamforge/processor/sink/IcebergSinkFactory.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/sink/IcebergSinkFactory.java
@@ -1,0 +1,129 @@
+package ai.streamforge.processor.sink;
+
+import ai.streamforge.processor.model.UserEventCount;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.CatalogLoader;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.sink.FlinkSink;
+import org.apache.iceberg.types.Types;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builds and attaches an Apache Iceberg sink to a {@link UserEventCount} stream.
+ *
+ * <p>Supported catalog types: {@code hadoop} (default), {@code hive}, {@code rest}.
+ * For MinIO / S3-compatible storage set the {@code ICEBERG_S3_*} environment variables
+ * so the Hadoop S3A filesystem is configured automatically.
+ */
+public class IcebergSinkFactory {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IcebergSinkFactory.class);
+
+    static final Schema TABLE_SCHEMA = new Schema(
+            Types.NestedField.required(1, "user_id",         Types.StringType.get()),
+            Types.NestedField.required(2, "event_count",     Types.LongType.get()),
+            Types.NestedField.required(3, "window_start_ms", Types.LongType.get()),
+            Types.NestedField.required(4, "window_end_ms",   Types.LongType.get())
+    );
+
+    /**
+     * Converts {@code stream} to Iceberg {@link RowData} and appends it to the
+     * specified Iceberg table, creating the namespace and table if absent.
+     */
+    public static void attach(
+            DataStream<UserEventCount> stream,
+            String catalogType,
+            String warehouse,
+            String database,
+            String tableName,
+            String s3Endpoint,
+            String s3AccessKey,
+            String s3SecretKey) {
+
+        Configuration hadoopConf = buildHadoopConf(s3Endpoint, s3AccessKey, s3SecretKey);
+        CatalogLoader catalogLoader = buildCatalogLoader(catalogType, warehouse, hadoopConf);
+        TableIdentifier tableId = TableIdentifier.of(database, tableName);
+
+        ensureTable(catalogLoader, tableId, database);
+
+        TableLoader tableLoader = TableLoader.fromCatalog(catalogLoader, tableId);
+
+        DataStream<RowData> rowData = stream
+                .map((MapFunction<UserEventCount, RowData>) e -> {
+                    GenericRowData row = new GenericRowData(4);
+                    row.setField(0, StringData.fromString(e.userId));
+                    row.setField(1, e.count);
+                    row.setField(2, e.windowStartMs);
+                    row.setField(3, e.windowEndMs);
+                    return row;
+                })
+                .returns(TypeInformation.of(RowData.class))
+                .name("Map to Iceberg RowData");
+
+        FlinkSink.forRowData(rowData)
+                .tableLoader(tableLoader)
+                .append()
+                .name("Iceberg Sink: " + database + "." + tableName);
+
+        LOG.info("Iceberg sink attached: catalog={}, warehouse={}, table={}.{}",
+                catalogType, warehouse, database, tableName);
+    }
+
+    private static CatalogLoader buildCatalogLoader(
+            String catalogType, String warehouse, Configuration hadoopConf) {
+        Map<String, String> props = new HashMap<>();
+        props.put("warehouse", warehouse);
+        return switch (catalogType.toLowerCase()) {
+            case "hadoop" -> CatalogLoader.hadoop("streamforge", hadoopConf, props);
+            case "hive"   -> CatalogLoader.hive("streamforge", hadoopConf, props);
+            case "rest"   -> {
+                props.put("uri", warehouse);
+                yield CatalogLoader.rest("streamforge", hadoopConf, props);
+            }
+            default -> throw new IllegalArgumentException(
+                    "Unsupported Iceberg catalog type: " + catalogType
+                    + ". Supported: hadoop, hive, rest");
+        };
+    }
+
+    private static void ensureTable(
+            CatalogLoader catalogLoader, TableIdentifier tableId, String database) {
+        Catalog catalog = catalogLoader.loadCatalog();
+        Namespace ns = Namespace.of(database);
+        if (!catalog.namespaceExists(ns)) {
+            catalog.createNamespace(ns);
+        }
+        if (!catalog.tableExists(tableId)) {
+            catalog.createTable(tableId, TABLE_SCHEMA, PartitionSpec.unpartitioned());
+            LOG.info("Created Iceberg table {}", tableId);
+        }
+    }
+
+    private static Configuration buildHadoopConf(
+            String s3Endpoint, String s3AccessKey, String s3SecretKey) {
+        Configuration conf = new Configuration();
+        if (s3Endpoint != null && !s3Endpoint.isBlank()) {
+            conf.set("fs.s3a.endpoint",          s3Endpoint);
+            conf.set("fs.s3a.access.key",        s3AccessKey != null ? s3AccessKey : "");
+            conf.set("fs.s3a.secret.key",        s3SecretKey != null ? s3SecretKey : "");
+            conf.set("fs.s3a.path.style.access", "true");
+            conf.set("fs.s3a.impl",              "org.apache.hadoop.fs.s3a.S3AFileSystem");
+        }
+        return conf;
+    }
+}


### PR DESCRIPTION
Adds an opt-in Iceberg sink alongside the existing Kafka sink so UserEventCount aggregates can be landed as Parquet files in a lakehouse (local filesystem or S3/MinIO).