### PR TITLE
feat(stream-processor): implement schema evolution handling for CDC s…

### DIFF
--- a/stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java
@@ -1,8 +1,11 @@
 package ai.streamforge.processor;
 
-import ai.streamforge.processor.deserialization.CdcEventDeserializationSchema;
+import ai.streamforge.processor.deserialization.SchemaAwareCdcDeserializationSchema;
+import ai.streamforge.processor.deserialization.SchemaEvolutionFilter;
 import ai.streamforge.processor.model.CdcEvent;
+import ai.streamforge.processor.model.DeadLetterEvent;
 import ai.streamforge.processor.model.UserEventCount;
+import ai.streamforge.processor.serialization.DeadLetterEventSerializationSchema;
 import ai.streamforge.processor.serialization.UserEventCountSerializationSchema;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
@@ -11,6 +14,7 @@ import org.apache.flink.connector.kafka.sink.KafkaSink;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
@@ -34,6 +38,7 @@ import java.time.Duration;
  *   <li>{@code KAFKA_BOOTSTRAP_SERVERS}  — default {@code localhost:9092}</li>
  *   <li>{@code KAFKA_SOURCE_TOPIC}       — default {@code cdc.streamforge.user_events}</li>
  *   <li>{@code KAFKA_SINK_TOPIC}         — default {@code user.event.counts}</li>
+ *   <li>{@code KAFKA_DLQ_TOPIC}          — default {@code cdc.dead.letter}; set empty to disable</li>
  *   <li>{@code KAFKA_CONSUMER_GROUP}     — default {@code flink-cdc-user-event-count}</li>
  *   <li>{@code WINDOW_SIZE_SECONDS}      — default {@code 60}</li>
  *   <li>{@code OUT_OF_ORDERNESS_SECONDS} — default {@code 5}</li>
@@ -44,18 +49,18 @@ public class CdcUserEventCountJob {
     private static final Logger LOG = LoggerFactory.getLogger(CdcUserEventCountJob.class);
 
     public static void main(String[] args) throws Exception {
-        String bootstrapServers    = env("KAFKA_BOOTSTRAP_SERVERS",  "localhost:9092");
-        String sourceTopic         = env("KAFKA_SOURCE_TOPIC",       "cdc.streamforge.user_events");
-        String sinkTopic           = env("KAFKA_SINK_TOPIC",         "user.event.counts");
-        String consumerGroup       = env("KAFKA_CONSUMER_GROUP",     "flink-cdc-user-event-count");
-        long   windowSizeSeconds   = Long.parseLong(env("WINDOW_SIZE_SECONDS",      "60"));
+        String bootstrapServers      = env("KAFKA_BOOTSTRAP_SERVERS",  "localhost:9092");
+        String sourceTopic           = env("KAFKA_SOURCE_TOPIC",       "cdc.streamforge.user_events");
+        String sinkTopic             = env("KAFKA_SINK_TOPIC",         "user.event.counts");
+        String dlqTopic              = env("KAFKA_DLQ_TOPIC",          "cdc.dead.letter");
+        String consumerGroup         = env("KAFKA_CONSUMER_GROUP",     "flink-cdc-user-event-count");
+        long   windowSizeSeconds     = Long.parseLong(env("WINDOW_SIZE_SECONDS",      "60"));
         long   outOfOrdernessSeconds = Long.parseLong(env("OUT_OF_ORDERNESS_SECONDS", "5"));
 
-        LOG.info("Starting CdcUserEventCountJob: source={}, sink={}, window={}s",
-                sourceTopic, sinkTopic, windowSizeSeconds);
+        LOG.info("Starting CdcUserEventCountJob: source={}, sink={}, dlq={}, window={}s",
+                sourceTopic, sinkTopic, dlqTopic.isBlank() ? "disabled" : dlqTopic, windowSizeSeconds);
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        // Checkpoint every 30 s for exactly-once semantics with Kafka.
         env.enableCheckpointing(30_000);
 
         KafkaSource<CdcEvent> source = KafkaSource.<CdcEvent>builder()
@@ -63,19 +68,39 @@ public class CdcUserEventCountJob {
                 .setTopics(sourceTopic)
                 .setGroupId(consumerGroup)
                 .setStartingOffsets(OffsetsInitializer.earliest())
-                .setValueOnlyDeserializer(new CdcEventDeserializationSchema())
+                .setValueOnlyDeserializer(new SchemaAwareCdcDeserializationSchema())
                 .build();
 
         WatermarkStrategy<CdcEvent> watermarkStrategy = WatermarkStrategy
                 .<CdcEvent>forBoundedOutOfOrderness(Duration.ofSeconds(outOfOrdernessSeconds))
                 .withTimestampAssigner((event, recordTimestamp) -> event.tsMs)
-                // Mark partition idle after 1 min so watermarks can advance
-                // even when some Kafka partitions receive no data.
                 .withIdleness(Duration.ofMinutes(1));
 
-        DataStream<UserEventCount> counts = env
+        // ── Schema evolution filter + dead-letter routing ────────────────────
+        SingleOutputStreamOperator<CdcEvent> filteredEvents = env
                 .fromSource(source, watermarkStrategy, "Kafka CDC Source")
-                // Only count new inserts; ignore updates, deletes, and snapshot reads.
+                .process(new SchemaEvolutionFilter())
+                .name("Schema Evolution Filter");
+
+        DataStream<DeadLetterEvent> deadLetters =
+                filteredEvents.getSideOutput(SchemaEvolutionFilter.DLQ_TAG);
+
+        if (!dlqTopic.isBlank()) {
+            KafkaSink<DeadLetterEvent> dlqSink = KafkaSink.<DeadLetterEvent>builder()
+                    .setBootstrapServers(bootstrapServers)
+                    .setRecordSerializer(
+                            KafkaRecordSerializationSchema.<DeadLetterEvent>builder()
+                                    .setTopic(dlqTopic)
+                                    .setValueSerializationSchema(new DeadLetterEventSerializationSchema())
+                                    .build()
+                    ).build();
+            deadLetters.sinkTo(dlqSink).name("Kafka DLQ: " + dlqTopic);
+        } else {
+            deadLetters.print().name("DLQ Log");
+        }
+
+        // ── Main aggregation pipeline ────────────────────────────────────────
+        DataStream<UserEventCount> counts = filteredEvents
                 .filter(e -> "c".equals(e.op) && e.after != null && e.after.userId != null)
                 .name("Filter: inserts only")
                 .keyBy(e -> e.after.userId)

--- a/stream-processor/src/main/java/ai/streamforge/processor/deserialization/SchemaAwareCdcDeserializationSchema.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/deserialization/SchemaAwareCdcDeserializationSchema.java
@@ -1,0 +1,57 @@
+package ai.streamforge.processor.deserialization;
+
+import ai.streamforge.processor.model.CdcEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Drop-in replacement for {@link CdcEventDeserializationSchema} that adds schema
+ * evolution support via {@link SchemaEvolutionHandler}:
+ *
+ * <ul>
+ *   <li>Detects schema version (V1 / V2 / UNKNOWN) and stores it on the event.</li>
+ *   <li>Normalizes renamed fields (uid → user_id, type → event_type, ts → created_at).</li>
+ *   <li>Extracts V2 columns (session_id, ip_address) when present.</li>
+ *   <li>Logs and skips unparseable records instead of crashing the job; invalid
+ *       inserts are further routed to the dead-letter side output by
+ *       {@link SchemaEvolutionFilter}.</li>
+ * </ul>
+ */
+public class SchemaAwareCdcDeserializationSchema implements DeserializationSchema<CdcEvent> {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaAwareCdcDeserializationSchema.class);
+
+    private transient ObjectMapper objectMapper;
+
+    @Override
+    public void open(InitializationContext context) {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public CdcEvent deserialize(byte[] message) {
+        if (message == null) {
+            return null;
+        }
+        try {
+            return SchemaEvolutionHandler.handle(message, objectMapper);
+        } catch (Exception e) {
+            LOG.warn("Skipping unparseable CDC record ({}): {}", e.getClass().getSimpleName(), e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isEndOfStream(CdcEvent nextElement) {
+        return false;
+    }
+
+    @Override
+    public TypeInformation<CdcEvent> getProducedType() {
+        return TypeInformation.of(CdcEvent.class);
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/deserialization/SchemaEvolutionFilter.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/deserialization/SchemaEvolutionFilter.java
@@ -1,0 +1,53 @@
+package ai.streamforge.processor.deserialization;
+
+import ai.streamforge.processor.model.CdcEvent;
+import ai.streamforge.processor.model.DeadLetterEvent;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+
+/**
+ * Routes {@link CdcEvent} records between the main stream and the dead-letter
+ * side output.
+ *
+ * <p>A record is sent to the dead-letter queue when it is an insert ({@code op=c})
+ * or snapshot read ({@code op=r}) whose {@code after.userId} could not be resolved
+ * after schema normalization.  This covers the case where the column was renamed to
+ * an unrecognised alias or removed entirely.  All other events (updates, deletes,
+ * and valid inserts) pass through to the main output unchanged.
+ *
+ * <p>Wire in the job:
+ * <pre>{@code
+ * SingleOutputStreamOperator<CdcEvent> filtered =
+ *         rawEvents.process(new SchemaEvolutionFilter()).name("Schema Evolution Filter");
+ * DataStream<DeadLetterEvent> dlq = filtered.getSideOutput(SchemaEvolutionFilter.DLQ_TAG);
+ * }</pre>
+ */
+public class SchemaEvolutionFilter extends ProcessFunction<CdcEvent, CdcEvent> {
+
+    public static final OutputTag<DeadLetterEvent> DLQ_TAG =
+            new OutputTag<DeadLetterEvent>("dead-letter") {};
+
+    @Override
+    public void processElement(
+            CdcEvent event,
+            Context ctx,
+            Collector<CdcEvent> out) {
+
+        if (isInsertOrRead(event) && lacksUserId(event)) {
+            ctx.output(DLQ_TAG, new DeadLetterEvent(
+                    event.toString(),
+                    "user_id unresolvable after schema normalization (version=" + event.schemaVersion + ")"));
+            return;
+        }
+        out.collect(event);
+    }
+
+    private static boolean isInsertOrRead(CdcEvent event) {
+        return "c".equals(event.op) || "r".equals(event.op);
+    }
+
+    private static boolean lacksUserId(CdcEvent event) {
+        return event.after == null || event.after.userId == null;
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/deserialization/SchemaEvolutionHandler.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/deserialization/SchemaEvolutionHandler.java
@@ -1,0 +1,113 @@
+package ai.streamforge.processor.deserialization;
+
+import ai.streamforge.processor.model.CdcEvent;
+import ai.streamforge.processor.model.SchemaVersion;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+/**
+ * Stateless utility that normalizes a raw Debezium JSON payload into a
+ * {@link CdcEvent}, handling field aliases introduced by schema renames and
+ * detecting which schema version the event conforms to.
+ *
+ * <h3>Field aliases</h3>
+ * <table border="1">
+ *   <tr><th>Canonical field</th><th>Accepted aliases</th></tr>
+ *   <tr><td>user_id</td><td>uid</td></tr>
+ *   <tr><td>event_type</td><td>type</td></tr>
+ *   <tr><td>created_at</td><td>ts</td></tr>
+ * </table>
+ *
+ * <h3>Schema versions</h3>
+ * <ul>
+ *   <li>{@link SchemaVersion#V1} — original columns: user_id, event_type, created_at</li>
+ *   <li>{@link SchemaVersion#V2} — adds session_id and ip_address (both nullable)</li>
+ *   <li>{@link SchemaVersion#UNKNOWN} — after payload absent or key fields missing</li>
+ * </ul>
+ */
+public final class SchemaEvolutionHandler {
+
+    private SchemaEvolutionHandler() {}
+
+    /**
+     * Parses {@code bytes} into a {@link CdcEvent} with schema normalization applied.
+     *
+     * @throws IOException if the bytes are not valid JSON
+     */
+    public static CdcEvent handle(byte[] bytes, ObjectMapper mapper) throws IOException {
+        JsonNode root = mapper.readTree(bytes);
+
+        CdcEvent event = new CdcEvent();
+        event.op   = textOrNull(root, "op");
+        event.tsMs = root.path("ts_ms").asLong(0L);
+
+        JsonNode afterNode = root.path("after");
+        if (!afterNode.isMissingNode() && !afterNode.isNull()) {
+            event.after         = normalizeRow(afterNode);
+            event.schemaVersion = detectVersion(afterNode);
+        } else {
+            event.schemaVersion = SchemaVersion.UNKNOWN;
+        }
+
+        return event;
+    }
+
+    // ── Version detection ────────────────────────────────────────────────────
+
+    static SchemaVersion detectVersion(JsonNode afterNode) {
+        if (afterNode.has("session_id") || afterNode.has("ip_address")) {
+            return SchemaVersion.V2;
+        }
+        if (afterNode.has("user_id") || afterNode.has("uid")) {
+            return SchemaVersion.V1;
+        }
+        return SchemaVersion.UNKNOWN;
+    }
+
+    // ── Field normalization ──────────────────────────────────────────────────
+
+    static CdcEvent.UserEventRow normalizeRow(JsonNode afterNode) {
+        CdcEvent.UserEventRow row = new CdcEvent.UserEventRow();
+        // user_id — also accepts legacy alias "uid" (column renamed in some deployments)
+        row.userId    = coalesceText(afterNode, "user_id", "uid");
+        // event_type — also accepts abbreviated alias "type"
+        row.eventType = coalesceText(afterNode, "event_type", "type");
+        // created_at — also accepts shortened alias "ts"
+        row.createdAt = coalesceTimestamp(afterNode, "created_at", "ts");
+        // V2 fields (nullable; null when absent in V1 payloads)
+        row.sessionId = textOrNull(afterNode, "session_id");
+        row.ipAddress = textOrNull(afterNode, "ip_address");
+        return row;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    /** Returns the text value of the first non-null key found among {@code keys}. */
+    static String coalesceText(JsonNode node, String... keys) {
+        for (String key : keys) {
+            String val = textOrNull(node, key);
+            if (val != null) {
+                return val;
+            }
+        }
+        return null;
+    }
+
+    /** Returns the long value of the first non-null key found among {@code keys}. */
+    static Long coalesceTimestamp(JsonNode node, String... keys) {
+        for (String key : keys) {
+            JsonNode child = node.get(key);
+            if (child != null && !child.isNull()) {
+                return child.asLong();
+            }
+        }
+        return null;
+    }
+
+    static String textOrNull(JsonNode node, String field) {
+        JsonNode child = node.get(field);
+        return (child != null && !child.isNull()) ? child.asText() : null;
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/model/CdcEvent.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/model/CdcEvent.java
@@ -23,6 +23,12 @@ public class CdcEvent {
     /** Row state after the change — null for deletes. */
     public UserEventRow after;
 
+    /**
+     * Schema version detected by {@link ai.streamforge.processor.deserialization.SchemaEvolutionHandler}.
+     * Transient — not serialized to Kafka or persisted in Flink state.
+     */
+    public transient SchemaVersion schemaVersion = SchemaVersion.UNKNOWN;
+
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class UserEventRow {
 
@@ -35,5 +41,13 @@ public class CdcEvent {
         /** Application-level event timestamp (milliseconds since epoch). */
         @JsonProperty("created_at")
         public Long createdAt;
+
+        /** V2+: browser/app session identifier (nullable). */
+        @JsonProperty("session_id")
+        public String sessionId;
+
+        /** V2+: client IP address (nullable). */
+        @JsonProperty("ip_address")
+        public String ipAddress;
     }
 }

--- a/stream-processor/src/main/java/ai/streamforge/processor/model/DeadLetterEvent.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/model/DeadLetterEvent.java
@@ -1,0 +1,22 @@
+package ai.streamforge.processor.model;
+
+/** A CDC record that could not be processed; routed to the dead-letter Kafka topic. */
+public class DeadLetterEvent {
+
+    public String rawPayload;
+    public String errorMessage;
+    public long failedAtMs;
+
+    public DeadLetterEvent() {}
+
+    public DeadLetterEvent(String rawPayload, String errorMessage) {
+        this.rawPayload = rawPayload;
+        this.errorMessage = errorMessage;
+        this.failedAtMs = System.currentTimeMillis();
+    }
+
+    @Override
+    public String toString() {
+        return "DeadLetterEvent{error='" + errorMessage + "', failedAtMs=" + failedAtMs + "}";
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/model/SchemaVersion.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/model/SchemaVersion.java
@@ -1,0 +1,14 @@
+package ai.streamforge.processor.model;
+
+/**
+ * Tracks the schema version of an incoming {@link CdcEvent}, detected from
+ * which fields are present in the Debezium {@code after} payload.
+ */
+public enum SchemaVersion {
+    /** Original schema: user_id, event_type, created_at. */
+    V1,
+    /** Extended schema: adds session_id and ip_address (both nullable). */
+    V2,
+    /** Fields don't match any known version; treated as V1 with nulls for missing fields. */
+    UNKNOWN
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/serialization/DeadLetterEventSerializationSchema.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/serialization/DeadLetterEventSerializationSchema.java
@@ -1,0 +1,27 @@
+package ai.streamforge.processor.serialization;
+
+import ai.streamforge.processor.model.DeadLetterEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+
+/** Serializes {@link DeadLetterEvent} to JSON bytes for the dead-letter Kafka topic. */
+public class DeadLetterEventSerializationSchema implements SerializationSchema<DeadLetterEvent> {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient ObjectMapper objectMapper;
+
+    @Override
+    public void open(InitializationContext context) {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public byte[] serialize(DeadLetterEvent element) {
+        try {
+            return objectMapper.writeValueAsBytes(element);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize DeadLetterEvent: " + element, e);
+        }
+    }
+}

--- a/stream-processor/src/test/java/ai/streamforge/processor/SchemaEvolutionHandlerTest.java
+++ b/stream-processor/src/test/java/ai/streamforge/processor/SchemaEvolutionHandlerTest.java
@@ -1,0 +1,151 @@
+package ai.streamforge.processor;
+
+import ai.streamforge.processor.deserialization.SchemaEvolutionHandler;
+import ai.streamforge.processor.model.CdcEvent;
+import ai.streamforge.processor.model.SchemaVersion;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SchemaEvolutionHandlerTest {
+
+    private ObjectMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ObjectMapper();
+    }
+
+    // ── Schema version detection ─────────────────────────────────────────────
+
+    @Test
+    void detectsV1SchemaFromUserIdField() throws Exception {
+        String json = """
+                {"op":"c","ts_ms":1700000000000,
+                 "after":{"user_id":"u1","event_type":"click","created_at":1700000000000}}
+                """;
+        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
+        assertEquals(SchemaVersion.V1, event.schemaVersion);
+    }
+
+    @Test
+    void detectsV2SchemaWhenSessionIdPresent() throws Exception {
+        String json = """
+                {"op":"c","ts_ms":1700000000000,
+                 "after":{"user_id":"u1","event_type":"click","created_at":1700000000000,
+                           "session_id":"sess-abc","ip_address":"192.168.1.1"}}
+                """;
+        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
+        assertEquals(SchemaVersion.V2, event.schemaVersion);
+        assertEquals("sess-abc", event.after.sessionId);
+        assertEquals("192.168.1.1", event.after.ipAddress);
+    }
+
+    @Test
+    void detectsUnknownSchemaWhenAfterIsNull() throws Exception {
+        String json = """
+                {"op":"d","ts_ms":1700000000000,"after":null}
+                """;
+        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
+        assertEquals(SchemaVersion.UNKNOWN, event.schemaVersion);
+        assertNull(event.after);
+    }
+
+    // ── Field alias normalization ────────────────────────────────────────────
+
+    @Test
+    void normalizesUidAliasToUserId() throws Exception {
+        String json = """
+                {"op":"c","ts_ms":1700000000000,
+                 "after":{"uid":"user-renamed","event_type":"view","created_at":1700000000000}}
+                """;
+        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
+        assertEquals("user-renamed", event.after.userId);
+    }
+
+    @Test
+    void normalizesTypeAliasToEventType() throws Exception {
+        String json = """
+                {"op":"c","ts_ms":1700000000000,
+                 "after":{"user_id":"u1","type":"purchase","created_at":1700000000000}}
+                """;
+        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
+        assertEquals("purchase", event.after.eventType);
+    }
+
+    @Test
+    void normalizesTsAliasToCreatedAt() throws Exception {
+        String json = """
+                {"op":"c","ts_ms":1700000000000,
+                 "after":{"user_id":"u1","event_type":"click","ts":1699999999000}}
+                """;
+        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
+        assertEquals(1699999999000L, event.after.createdAt);
+    }
+
+    @Test
+    void canonicalFieldTakesPriorityOverAlias() throws Exception {
+        String json = """
+                {"op":"c","ts_ms":1700000000000,
+                 "after":{"user_id":"canonical","uid":"alias","event_type":"click","created_at":1700000000000}}
+                """;
+        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
+        assertEquals("canonical", event.after.userId);
+    }
+
+    // ── Missing / nullable fields ────────────────────────────────────────────
+
+    @Test
+    void toleratesMissingOptionalFields() throws Exception {
+        String json = """
+                {"op":"c","ts_ms":1700000000000,
+                 "after":{"user_id":"u1"}}
+                """;
+        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
+        assertEquals("u1", event.after.userId);
+        assertNull(event.after.eventType);
+        assertNull(event.after.createdAt);
+        assertNull(event.after.sessionId);
+        assertNull(event.after.ipAddress);
+    }
+
+    @Test
+    void toleratesNullFieldValues() throws Exception {
+        String json = """
+                {"op":"c","ts_ms":1700000000000,
+                 "after":{"user_id":"u1","event_type":null,"created_at":null}}
+                """;
+        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
+        assertEquals("u1", event.after.userId);
+        assertNull(event.after.eventType);
+        assertNull(event.after.createdAt);
+    }
+
+    // ── Envelope fields ──────────────────────────────────────────────────────
+
+    @Test
+    void parsesOpAndTsMs() throws Exception {
+        String json = """
+                {"op":"u","ts_ms":1700001234567,
+                 "after":{"user_id":"u2","event_type":"update","created_at":1700001234000}}
+                """;
+        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
+        assertEquals("u", event.op);
+        assertEquals(1700001234567L, event.tsMs);
+    }
+
+    @Test
+    void ignoresUnknownEnvelopeFields() throws Exception {
+        String json = """
+                {"op":"c","ts_ms":1700000000000,
+                 "source":{"connector":"mysql","table":"user_events"},
+                 "transaction":null,
+                 "after":{"user_id":"u1","event_type":"click","created_at":1700000000000}}
+                """;
+        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
+        assertEquals("c", event.op);
+        assertEquals("u1", event.after.userId);
+    }
+}


### PR DESCRIPTION
…tream

Adds version detection, field-alias normalization, and dead-letter routing so the Flink job survives MySQL schema changes (renames, new columns) without crashing or silently dropping data.