### PR TITLE
feat(stream-processor): add Flink-native metrics and observability su…

### DIFF
--- a/stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java
@@ -1,18 +1,22 @@
 package ai.streamforge.processor;
 
 import ai.streamforge.processor.deserialization.CdcEventDeserializationSchema;
+import ai.streamforge.processor.metrics.EventLagFunction;
+import ai.streamforge.processor.metrics.InsertFilterWithMetrics;
 import ai.streamforge.processor.model.CdcEvent;
 import ai.streamforge.processor.model.UserEventCount;
 import ai.streamforge.processor.serialization.UserEventCountSerializationSchema;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
 import org.apache.flink.connector.kafka.sink.KafkaSink;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.metrics.Counter;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.streaming.api.functions.windowing.ProcessWindowFunction;
+import org.apache.flink.streaming.api.functions.windowing.RichProcessWindowFunction;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
 import org.apache.flink.streaming.api.windowing.time.Time;
 import org.apache.flink.streaming.api.windowing.windows.TimeWindow;
@@ -75,9 +79,10 @@ public class CdcUserEventCountJob {
 
         DataStream<UserEventCount> counts = env
                 .fromSource(source, watermarkStrategy, "Kafka CDC Source")
-                // Only count new inserts; ignore updates, deletes, and snapshot reads.
-                .filter(e -> "c".equals(e.op) && e.after != null && e.after.userId != null)
-                .name("Filter: inserts only")
+                .map(new EventLagFunction())
+                .name("Metrics: event processing lag")
+                .filter(new InsertFilterWithMetrics())
+                .name("Filter: inserts only (with metrics)")
                 .keyBy(e -> e.after.userId)
                 .window(TumblingEventTimeWindows.of(Time.seconds(windowSizeSeconds)))
                 .aggregate(new EventCountAggregator(), new WindowMetadataFunction())
@@ -108,20 +113,36 @@ public class CdcUserEventCountJob {
         @Override public Long merge(Long a, Long b)         { return a + b; }
     }
 
-    /** Attaches window boundaries and the keyed userId to the final count. */
+    /**
+     * Attaches window boundaries and the keyed userId to the final count.
+     * Also increments two Flink metrics:
+     * <ul>
+     *   <li>{@code windows_fired_total} — one per window that produces output</li>
+     *   <li>{@code window_counts_emitted_total} — sum of all event counts across windows</li>
+     * </ul>
+     */
     static class WindowMetadataFunction
-            extends ProcessWindowFunction<Long, UserEventCount, String, TimeWindow> {
+            extends RichProcessWindowFunction<Long, UserEventCount, String, TimeWindow> {
+
+        private transient Counter windowsFired;
+        private transient Counter countsEmitted;
+
+        @Override
+        public void open(Configuration parameters) {
+            windowsFired   = getRuntimeContext().getMetricGroup().counter("windows_fired_total");
+            countsEmitted  = getRuntimeContext().getMetricGroup().counter("window_counts_emitted_total");
+        }
+
         @Override
         public void process(
                 String userId,
                 Context ctx,
                 Iterable<Long> counts,
                 Collector<UserEventCount> out) {
-            out.collect(new UserEventCount(
-                    userId,
-                    counts.iterator().next(),
-                    ctx.window().getStart(),
-                    ctx.window().getEnd()));
+            long count = counts.iterator().next();
+            windowsFired.inc();
+            countsEmitted.inc(count);
+            out.collect(new UserEventCount(userId, count, ctx.window().getStart(), ctx.window().getEnd()));
         }
     }
 

--- a/stream-processor/src/main/java/ai/streamforge/processor/metrics/EventLagFunction.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/metrics/EventLagFunction.java
@@ -1,0 +1,40 @@
+package ai.streamforge.processor.metrics;
+
+import ai.streamforge.processor.model.CdcEvent;
+import org.apache.flink.api.common.functions.RichMapFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.util.DescriptiveStatisticsHistogram;
+
+/**
+ * Pass-through operator that measures the lag between the Debezium event
+ * timestamp ({@code ts_ms}) and the wall-clock time when Flink processes
+ * the record, recording each sample in a histogram (milliseconds).
+ *
+ * <p>High p99 lag indicates the consumer is falling behind the CDC source.
+ * Metric name: {@code event_processing_lag_ms}.
+ *
+ * <p>The histogram retains the last {@value #HISTOGRAM_SIZE} samples; this
+ * is large enough to give stable percentiles without unbounded memory use.
+ */
+public class EventLagFunction extends RichMapFunction<CdcEvent, CdcEvent> {
+
+    private static final int HISTOGRAM_SIZE = 1024;
+
+    private transient Histogram eventLagMs;
+
+    @Override
+    public void open(Configuration parameters) {
+        eventLagMs = getRuntimeContext().getMetricGroup()
+                .histogram("event_processing_lag_ms", new DescriptiveStatisticsHistogram(HISTOGRAM_SIZE));
+    }
+
+    @Override
+    public CdcEvent map(CdcEvent event) {
+        long lag = System.currentTimeMillis() - event.tsMs;
+        if (lag >= 0) {
+            eventLagMs.update(lag);
+        }
+        return event;
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/metrics/InsertFilterWithMetrics.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/metrics/InsertFilterWithMetrics.java
@@ -1,0 +1,56 @@
+package ai.streamforge.processor.metrics;
+
+import ai.streamforge.processor.model.CdcEvent;
+import org.apache.flink.api.common.functions.RichFilterFunction;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Meter;
+import org.apache.flink.metrics.MeterView;
+
+/**
+ * Replaces the inline insert-filter lambda in the job pipeline and exposes
+ * three Flink metrics per task-manager instance:
+ *
+ * <ul>
+ *   <li>{@code events_received_total}   — every event seen by this operator</li>
+ *   <li>{@code insert_events_total}     — op=c events with a non-null userId that pass through</li>
+ *   <li>{@code non_insert_events_total} — all other events (updates, deletes, snapshots)</li>
+ *   <li>{@code insert_events_per_second} — 60-second sliding rate of inserts (Meter)</li>
+ * </ul>
+ *
+ * <p>Metrics are scoped to the Flink operator metric group and can be scraped
+ * via the Prometheus reporter — see {@code flink-metrics-example.properties}.
+ */
+public class InsertFilterWithMetrics extends RichFilterFunction<CdcEvent> {
+
+    private transient Counter eventsReceived;
+    private transient Counter insertsTotal;
+    private transient Counter nonInsertsTotal;
+    private transient Meter  insertsPerSecond;
+
+    @Override
+    public void open(Configuration parameters) {
+        eventsReceived   = getRuntimeContext().getMetricGroup().counter("events_received_total");
+        insertsTotal     = getRuntimeContext().getMetricGroup().counter("insert_events_total");
+        nonInsertsTotal  = getRuntimeContext().getMetricGroup().counter("non_insert_events_total");
+        insertsPerSecond = getRuntimeContext().getMetricGroup()
+                .meter("insert_events_per_second", new MeterView(60));
+    }
+
+    @Override
+    public boolean filter(CdcEvent event) {
+        eventsReceived.inc();
+        if (isValidInsert(event)) {
+            insertsTotal.inc();
+            insertsPerSecond.markEvent();
+            return true;
+        }
+        nonInsertsTotal.inc();
+        return false;
+    }
+
+    /** Extracted for unit-testability without a Flink runtime context. */
+    static boolean isValidInsert(CdcEvent event) {
+        return "c".equals(event.op) && event.after != null && event.after.userId != null;
+    }
+}

--- a/stream-processor/src/main/resources/flink-metrics-example.properties
+++ b/stream-processor/src/main/resources/flink-metrics-example.properties
@@ -1,0 +1,40 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Flink Prometheus metrics reporter — example configuration
+#
+# Copy the relevant sections into your Flink cluster's flink-conf.yaml, then
+# place the reporter JAR in $FLINK_HOME/plugins/metrics-prometheus/:
+#
+#   wget https://repo1.maven.org/maven2/org/apache/flink/flink-metrics-prometheus/1.18.1/flink-metrics-prometheus-1.18.1.jar \
+#        -P $FLINK_HOME/plugins/metrics-prometheus/
+# ──────────────────────────────────────────────────────────────────────────────
+
+# ── Pull model (Prometheus scrapes Flink directly) ───────────────────────────
+metrics.reporters: prometheus
+metrics.reporter.prometheus.factory.class: org.apache.flink.metrics.prometheus.PrometheusReporterFactory
+# Each TaskManager exposes metrics on this port (use a range for multi-TM hosts)
+metrics.reporter.prometheus.port: 9250
+
+# ── Push model (Flink pushes to Prometheus Pushgateway) ──────────────────────
+# Useful when the Flink cluster is behind a NAT or firewall.
+#
+# metrics.reporters: pushgateway
+# metrics.reporter.pushgateway.factory.class: org.apache.flink.metrics.prometheus.PrometheusPushGatewayReporterFactory
+# metrics.reporter.pushgateway.host: localhost
+# metrics.reporter.pushgateway.port: 9091
+# metrics.reporter.pushgateway.jobName: flink-cdc-stream-processor
+# metrics.reporter.pushgateway.randomJobNameSuffix: true
+# metrics.reporter.pushgateway.interval: 60 SECONDS
+# metrics.reporter.pushgateway.groupingKey: job_id=stream-processor
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Key metrics emitted by CdcUserEventCountJob
+# (visible under the flink_taskmanager_job_task_operator_* namespace in Prometheus)
+#
+#   events_received_total        — CDC events entering the filter stage
+#   insert_events_total          — op=c events with a valid userId
+#   non_insert_events_total      — updates, deletes, snapshot reads
+#   insert_events_per_second     — 60-second sliding insert rate
+#   event_processing_lag_ms      — histogram: Debezium ts_ms → Flink processing time
+#   windows_fired_total          — tumbling windows that completed and emitted a result
+#   window_counts_emitted_total  — total event-count records written to the sink topic
+# ──────────────────────────────────────────────────────────────────────────────

--- a/stream-processor/src/test/java/ai/streamforge/processor/InsertFilterWithMetricsTest.java
+++ b/stream-processor/src/test/java/ai/streamforge/processor/InsertFilterWithMetricsTest.java
@@ -1,0 +1,84 @@
+package ai.streamforge.processor;
+
+import ai.streamforge.processor.metrics.InsertFilterWithMetrics;
+import ai.streamforge.processor.model.CdcEvent;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests the filter predicate logic of {@link InsertFilterWithMetrics} without
+ * a Flink runtime context (metrics counters are not exercised here).
+ */
+class InsertFilterWithMetricsTest {
+
+    // ── insert events that should pass ──────────────────────────────────────
+
+    @Test
+    void acceptsInsertWithValidUserId() {
+        CdcEvent event = insertEvent("user-1");
+        assertTrue(InsertFilterWithMetrics.isValidInsert(event));
+    }
+
+    // ── events that should be dropped ───────────────────────────────────────
+
+    @Test
+    void rejectsUpdateEvent() {
+        CdcEvent event = eventWithOp("u", "user-1");
+        assertFalse(InsertFilterWithMetrics.isValidInsert(event));
+    }
+
+    @Test
+    void rejectsDeleteEvent() {
+        CdcEvent event = eventWithOp("d", null);
+        assertFalse(InsertFilterWithMetrics.isValidInsert(event));
+    }
+
+    @Test
+    void rejectsSnapshotReadEvent() {
+        CdcEvent event = eventWithOp("r", "user-1");
+        assertFalse(InsertFilterWithMetrics.isValidInsert(event));
+    }
+
+    @Test
+    void rejectsInsertWithNullAfter() {
+        CdcEvent event = new CdcEvent();
+        event.op = "c";
+        event.after = null;
+        assertFalse(InsertFilterWithMetrics.isValidInsert(event));
+    }
+
+    @Test
+    void rejectsInsertWithNullUserId() {
+        CdcEvent event = new CdcEvent();
+        event.op = "c";
+        event.after = new CdcEvent.UserEventRow();
+        event.after.userId = null;
+        assertFalse(InsertFilterWithMetrics.isValidInsert(event));
+    }
+
+    @Test
+    void rejectsInsertWithBlankUserId() {
+        // userId that is empty string is technically non-null — treated as valid by the filter.
+        // This test documents that behaviour explicitly.
+        CdcEvent event = insertEvent("");
+        assertTrue(InsertFilterWithMetrics.isValidInsert(event),
+                "empty-string userId is non-null; downstream logic owns userId validation");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    private static CdcEvent insertEvent(String userId) {
+        return eventWithOp("c", userId);
+    }
+
+    private static CdcEvent eventWithOp(String op, String userId) {
+        CdcEvent event = new CdcEvent();
+        event.op = op;
+        if (userId != null) {
+            event.after = new CdcEvent.UserEventRow();
+            event.after.userId = userId;
+        }
+        return event;
+    }
+}


### PR DESCRIPTION
…pport

Instruments the CDC pipeline with Flink counters, a meter, and a histogram so operators can be monitored via the Flink Web UI or Prometheus reporter.