### PR TITLE
feat(benchmarks): add reproducible benchmarks for CDC, Flink, MinIO, …

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,157 @@
+# StreamForge AI — Benchmark Suite
+
+Reproducible performance benchmarks covering every major component of the
+StreamForge AI data pipeline.
+
+## Quick start
+
+```bash
+# All benchmarks (no external services required)
+python benchmarks/run_all.py
+
+# Single component
+python benchmarks/run_all.py --component cdc
+python benchmarks/run_all.py --component flink
+python benchmarks/run_all.py --component minio
+python benchmarks/run_all.py --component cache_hitrate
+python benchmarks/run_all.py --component prefetch
+```
+
+Or run any benchmark directly:
+
+```bash
+python benchmarks/cdc_ingestion_throughput.py
+python benchmarks/flink_job_latency.py
+python benchmarks/minio_write_throughput.py
+python benchmarks/prefetch_cache_hitrate.py
+```
+
+## Benchmarks
+
+### 1. CDC Ingestion Throughput (`cdc_ingestion_throughput.py`)
+
+Measures how fast the CDC ingestion layer can parse and filter Debezium CDC
+envelopes — the same JSON format produced by the MySQL connector in
+`deploy/cdc-mysql-kafka-debezium/`.
+
+| Metric | Description |
+|--------|-------------|
+| `Throughput (events/s)` | Total events parsed and filtered per second |
+| `INS/s` | INSERT events accepted by the op-filter per second |
+| `DLQ%` | Fraction of INSERT events routed to the dead-letter queue (schema drift) |
+| `p50 / p99 µs` | Per-event parse latency percentiles |
+| `MB/s` | Raw byte processing throughput |
+
+**Scenarios** cover: inserts-only, mixed ops, high-volume (50k events),
+schema-drift at 5% and 25%, delete-heavy workloads.
+
+**Live Kafka mode** (optional): set `KAFKA_BOOTSTRAP_SERVERS` to also measure
+real consumer throughput against a running broker.
+
+---
+
+### 2. Flink Job Latency (`flink_job_latency.py`)
+
+Replays the four pipeline stages of `CdcUserEventCountJob` in pure Python to
+measure per-stage latency and overall throughput:
+
+1. **Deserialisation** — JSON bytes → `CdcEvent`
+2. **Filter** — `op == "c"` + schema-version guard
+3. **Window aggregation** — tumbling time-window count (mirrors `TumblingEventTimeWindows`)
+4. **Serialisation** — `WindowResult` → JSON bytes
+
+| Metric | Description |
+|--------|-------------|
+| `E2E ms` | Total pipeline latency for the full event stream |
+| `Deser ms` | Deserialisation stage time |
+| `Win ms` | Window aggregation stage time |
+| `Ser ms` | Serialisation stage time |
+| `Events/s` | End-to-end processing throughput |
+
+**Scenarios** sweep window sizes (10 s / 30 s / 60 s), stream sizes
+(1k / 10k / 50k events), and insert ratios (30% / 90%).
+
+---
+
+### 3. MinIO Write Throughput (`minio_write_throughput.py`)
+
+Measures object write throughput against MinIO, mirroring the access pattern
+of `deploy/cdc-flink-minio-demo/feature-sink/feature_to_minio.py`.
+
+| Metric | Description |
+|--------|-------------|
+| `ops/s` | PUT operations per second |
+| `MB/s` | Raw write throughput |
+| `p50 / p99 ms` | PUT latency percentiles |
+
+**Two modes** (auto-detected):
+- **Live MinIO** — writes real objects when a broker is reachable.
+- **Filesystem simulation** — writes to a temp directory for CI/CD runs.
+
+**Environment variables** (matching deploy defaults):
+
+```
+MINIO_ENDPOINT    localhost:9000
+MINIO_ACCESS_KEY  minioadmin
+MINIO_SECRET_KEY  minioadmin
+MINIO_SECURE      false
+MINIO_BUCKET      processed
+MINIO_PREFIX      benchmarks
+```
+
+**Scenarios** sweep object sizes (1 KB → 1 MB), object counts, and
+concurrency levels (1 and 4 parallel writer threads).
+
+---
+
+### 4. Prefetch Cache Hit-Ratio vs Cold-Start Time (`prefetch_cache_hitrate.py`)
+
+Quantifies the relationship between the prefetch-engine's cache hit-ratio and
+ML job cold-start latency, sweeping hit ratios from 0% to 100% across three
+dataset sizes.
+
+| Metric | Description |
+|--------|-------------|
+| `Cold-start ms` | Total time from job start to all files processed |
+| `TTFB ms` | Time-to-first-batch: latency to the first record |
+| `Speedup` | Cold-start improvement vs 0% hit-ratio baseline |
+| `Prefetch ms` | Time spent staging hot files into local cache |
+| `Miss penalty ms` | Average remote I/O penalty per cache miss |
+
+**Hit-ratio sweep**: 0%, 25%, 50%, 75%, 100%  
+**Datasets**: Small (10 files), Medium (50 files), Large (200 files)
+
+Latency constants match `prefetch-engine/benchmark.py`:
+- Remote (MinIO) latency: 50 ms/file
+- Local (cache) latency: 2 ms/file
+
+---
+
+### Legacy benchmarks (existing)
+
+| Component | File | Description |
+|-----------|------|-------------|
+| `prefetch` | `prefetch-engine/benchmark.py` | Multi-scenario prefetch benefit analysis |
+| `rag` | `rag-engine/benchmark_rag.py` | RAG engine retrieval benchmarks |
+| `workflow` | `agent-workflow/benchmark_workflow.py` | Agent workflow orchestration benchmarks |
+
+## Reproducibility
+
+All new benchmarks use a fixed `RANDOM_SEED = 42`. Given the same Python
+version and OS, successive runs should produce byte-identical payloads and
+differ only in wall-clock timings (±5% due to OS scheduling noise).
+
+To compare runs across machines, focus on **relative metrics** (speedup,
+reduction%, stage fractions) rather than absolute wall-clock times.
+
+## Requirements
+
+The four new benchmarks have **zero extra dependencies** beyond the Python
+standard library. The MinIO benchmark optionally uses the `minio` package
+(already listed in `prefetch-engine/requirements.txt`) when a live MinIO
+instance is available.
+
+```
+python >= 3.9
+minio >= 7.2.7   # optional, for live MinIO mode only
+```

--- a/benchmarks/cdc_ingestion_throughput.py
+++ b/benchmarks/cdc_ingestion_throughput.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""
+StreamForge AI — CDC Ingestion Throughput Benchmark
+
+Measures the throughput of the CDC ingestion pipeline:
+  1. Debezium JSON envelope serialisation / deserialisation rate (events/s)
+  2. Schema-validation + filter throughput for INSERT-only workloads
+  3. Throughput degradation under schema-evolution (DLQ routing overhead)
+
+The benchmark is fully self-contained: no running Kafka or MySQL is required.
+If a Kafka broker is reachable at KAFKA_BOOTSTRAP_SERVERS it will additionally
+measure real consumer throughput via the kafka-python library (skipped otherwise).
+
+Reproducibility knobs
+---------------------
+All random data is seeded so successive runs produce identical payloads.
+Latency constants match the Debezium-MySQL connector defaults used in
+deploy/cdc-mysql-kafka-debezium/.
+"""
+
+import json
+import os
+import random
+import statistics
+import time
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+RANDOM_SEED = 42
+random.seed(RANDOM_SEED)
+
+# ---------------------------------------------------------------------------
+# Debezium CDC envelope helpers
+# ---------------------------------------------------------------------------
+
+_NAMES = ["Alice", "Bob", "Carol", "Dave", "Eve", "Frank", "Grace", "Heidi"]
+_DOMAINS = ["example.com", "streamforge.io", "acme.org", "test.net"]
+
+
+def _make_customer(cid: int) -> dict:
+    name = _NAMES[cid % len(_NAMES)]
+    domain = _DOMAINS[cid % len(_DOMAINS)]
+    return {"id": cid, "name": name, "email": f"{name.lower()}{cid}@{domain}",
+            "updated_at": "2024-01-15T10:00:00Z", "created_at": "2024-01-01T00:00:00Z"}
+
+
+def _debezium_envelope(op: str, after: Optional[dict], before: Optional[dict] = None,
+                       schema_version: int = 1) -> bytes:
+    """Return a serialised Debezium MySQL CDC envelope (JSON bytes)."""
+    envelope = {
+        "schema": {"type": "struct", "version": schema_version},
+        "payload": {
+            "before": before,
+            "after": after,
+            "source": {
+                "version": "2.5.0.Final",
+                "connector": "mysql",
+                "name": "streamforge",
+                "ts_ms": int(time.time() * 1000),
+                "db": "streamforge",
+                "table": "customers",
+                "server_id": 184054,
+            },
+            "op": op,
+            "ts_ms": int(time.time() * 1000),
+        },
+    }
+    return json.dumps(envelope).encode()
+
+
+def _make_insert(cid: int, schema_version: int = 1) -> bytes:
+    return _debezium_envelope("c", _make_customer(cid), schema_version=schema_version)
+
+
+def _make_update(cid: int) -> bytes:
+    before = _make_customer(cid)
+    after = {**before, "name": before["name"] + "_updated"}
+    return _debezium_envelope("u", after, before)
+
+
+def _make_delete(cid: int) -> bytes:
+    return _debezium_envelope("d", None, _make_customer(cid))
+
+
+# ---------------------------------------------------------------------------
+# Parsing / filtering logic (mirrors CdcUserEventCountJob logic)
+# ---------------------------------------------------------------------------
+
+def _parse_and_filter(raw: bytes) -> Optional[dict]:
+    """Parse a CDC envelope and return the 'after' payload for INSERT events."""
+    envelope = json.loads(raw)
+    op = envelope["payload"]["op"]
+    if op != "c":
+        return None
+    return envelope["payload"]["after"]
+
+
+def _parse_with_schema_check(raw: bytes, expected_version: int = 1) -> Optional[dict]:
+    """Parse + validate schema version; return None (DLQ) on mismatch."""
+    envelope = json.loads(raw)
+    version = envelope["schema"].get("version", 1)
+    if version != expected_version:
+        return None  # would go to DLQ in production
+    return _parse_and_filter(raw)
+
+
+# ---------------------------------------------------------------------------
+# Scenario definitions
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CdcScenarioConfig:
+    name: str
+    num_events: int
+    insert_pct: float   # fraction of events that are INSERTs
+    schema_drift_pct: float = 0.0   # fraction of INSERTs with wrong schema version
+    repeat: int = 3
+
+
+@dataclass
+class CdcBenchmarkResult:
+    scenario: str
+    num_events: int
+    throughput_eps: float          # events per second (parse + filter)
+    insert_throughput_eps: float   # INSERTs accepted per second
+    dlq_rate_pct: float            # percentage routed to DLQ
+    p50_us: float                  # median per-event latency (µs)
+    p99_us: float                  # 99th-percentile per-event latency (µs)
+    payload_mb_s: float            # MB/s of raw bytes processed
+
+
+SCENARIOS: List[CdcScenarioConfig] = [
+    CdcScenarioConfig("Inserts only         (10k events, 100% INSERT)",
+                      num_events=10_000, insert_pct=1.0),
+    CdcScenarioConfig("Mixed ops            (10k events,  60% INSERT)",
+                      num_events=10_000, insert_pct=0.6),
+    CdcScenarioConfig("High volume          (50k events, 100% INSERT)",
+                      num_events=50_000, insert_pct=1.0),
+    CdcScenarioConfig("Schema drift  5%     (10k events, schema errors)",
+                      num_events=10_000, insert_pct=1.0, schema_drift_pct=0.05),
+    CdcScenarioConfig("Schema drift 25%     (10k events, schema errors)",
+                      num_events=10_000, insert_pct=1.0, schema_drift_pct=0.25),
+    CdcScenarioConfig("Delete-heavy         (10k events,  10% INSERT)",
+                      num_events=10_000, insert_pct=0.1),
+]
+
+
+# ---------------------------------------------------------------------------
+# Benchmark execution
+# ---------------------------------------------------------------------------
+
+def _build_payloads(cfg: CdcScenarioConfig) -> List[bytes]:
+    rng = random.Random(RANDOM_SEED)
+    payloads = []
+    for i in range(cfg.num_events):
+        r = rng.random()
+        if r < cfg.insert_pct:
+            drift = rng.random() < cfg.schema_drift_pct
+            payloads.append(_make_insert(i, schema_version=2 if drift else 1))
+        elif r < cfg.insert_pct + (1 - cfg.insert_pct) / 2:
+            payloads.append(_make_update(i))
+        else:
+            payloads.append(_make_delete(i))
+    return payloads
+
+
+def _run_single(payloads: List[bytes]) -> tuple:
+    """Returns (total_s, inserts_accepted, dlq_count, per_event_latencies_us, total_bytes)."""
+    latencies_us: List[float] = []
+    inserts = 0
+    dlq = 0
+    total_bytes = sum(len(p) for p in payloads)
+
+    t0 = time.perf_counter()
+    for raw in payloads:
+        ev_start = time.perf_counter()
+        result = _parse_with_schema_check(raw)
+        ev_end = time.perf_counter()
+        latencies_us.append((ev_end - ev_start) * 1e6)
+        if result is not None:
+            inserts += 1
+        else:
+            envelope = json.loads(raw)
+            if envelope["payload"]["op"] == "c":
+                dlq += 1
+    total_s = time.perf_counter() - t0
+    return total_s, inserts, dlq, latencies_us, total_bytes
+
+
+def run_scenario(cfg: CdcScenarioConfig) -> CdcBenchmarkResult:
+    payloads = _build_payloads(cfg)
+
+    all_eps, all_insert_eps, all_dlq, all_p50, all_p99, all_mbps = [], [], [], [], [], []
+
+    for _ in range(cfg.repeat):
+        total_s, inserts, dlq, lats, total_bytes = _run_single(payloads)
+        all_eps.append(len(payloads) / total_s)
+        all_insert_eps.append(inserts / total_s)
+        all_dlq.append(dlq / max(1, sum(1 for p in payloads
+                                        if json.loads(p)["payload"]["op"] == "c")) * 100)
+        sorted_lats = sorted(lats)
+        all_p50.append(sorted_lats[len(sorted_lats) // 2])
+        all_p99.append(sorted_lats[int(len(sorted_lats) * 0.99)])
+        all_mbps.append(total_bytes / total_s / 1e6)
+
+    return CdcBenchmarkResult(
+        scenario=cfg.name,
+        num_events=cfg.num_events,
+        throughput_eps=statistics.mean(all_eps),
+        insert_throughput_eps=statistics.mean(all_insert_eps),
+        dlq_rate_pct=statistics.mean(all_dlq),
+        p50_us=statistics.mean(all_p50),
+        p99_us=statistics.mean(all_p99),
+        payload_mb_s=statistics.mean(all_mbps),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Kafka live consumer (optional — skipped if broker unreachable)
+# ---------------------------------------------------------------------------
+
+def _try_kafka_throughput() -> Optional[dict]:
+    bootstrap = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+    topic = os.environ.get("KAFKA_SOURCE_TOPIC", "streamforge.streamforge.customers")
+    try:
+        from kafka import KafkaConsumer  # type: ignore
+        from kafka.errors import NoBrokersAvailable  # type: ignore
+    except ImportError:
+        return None
+
+    try:
+        consumer = KafkaConsumer(
+            topic,
+            bootstrap_servers=bootstrap,
+            auto_offset_reset="earliest",
+            consumer_timeout_ms=3000,
+            value_deserializer=lambda b: b,
+        )
+    except Exception:
+        return None
+
+    try:
+        count = 0
+        total_bytes = 0
+        t0 = time.perf_counter()
+        for msg in consumer:
+            count += 1
+            total_bytes += len(msg.value)
+            if time.perf_counter() - t0 > 5.0:
+                break
+        elapsed = time.perf_counter() - t0
+        consumer.close()
+        if count == 0:
+            return None
+        return {
+            "events": count,
+            "elapsed_s": elapsed,
+            "throughput_eps": count / elapsed,
+            "throughput_mbps": total_bytes / elapsed / 1e6,
+        }
+    except Exception:
+        consumer.close()
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def _print_results(results: List[CdcBenchmarkResult]) -> None:
+    w = 90
+    print("\n" + "=" * w)
+    print("          StreamForge AI: CDC Ingestion Throughput Benchmark Results")
+    print("=" * w)
+    hdr = (f"{'Scenario':<45} {'Throughput':>11} {'INS/s':>9} "
+           f"{'DLQ%':>6} {'p50µs':>7} {'p99µs':>7} {'MB/s':>6}")
+    print(hdr)
+    print("-" * w)
+    for r in results:
+        print(
+            f"{r.scenario:<45} {r.throughput_eps:>10,.0f} {r.insert_throughput_eps:>9,.0f}"
+            f" {r.dlq_rate_pct:>5.1f}% {r.p50_us:>7.1f} {r.p99_us:>7.1f} {r.payload_mb_s:>6.2f}"
+        )
+    print("=" * w)
+    print("  Throughput = total events/s parsed+filtered (in-process, no network)")
+    print("  INS/s      = INSERT events accepted by filter per second")
+    print("  DLQ%       = fraction of INSERT events routed to dead-letter queue")
+    print("  p50/p99    = per-event parse latency percentiles (microseconds)")
+    print("=" * w)
+
+
+def run_benchmark() -> List[CdcBenchmarkResult]:
+    print("=" * 70)
+    print("      StreamForge AI: CDC Ingestion — Throughput Benchmark")
+    print("=" * 70)
+    print(f"  Seed: {RANDOM_SEED}  |  Scenarios: {len(SCENARIOS)}")
+    print("  (No external services required — uses simulated Debezium payloads)\n")
+
+    results = []
+    for i, cfg in enumerate(SCENARIOS, 1):
+        print(f"  [{i}/{len(SCENARIOS)}] {cfg.name} ...", end=" ", flush=True)
+        r = run_scenario(cfg)
+        results.append(r)
+        print(f"done  ({r.throughput_eps:,.0f} events/s, p99={r.p99_us:.1f}µs)")
+
+    _print_results(results)
+
+    kafka_result = _try_kafka_throughput()
+    if kafka_result:
+        print("\n  [Live Kafka] consumer throughput:")
+        print(f"    Events consumed : {kafka_result['events']:,}")
+        print(f"    Elapsed         : {kafka_result['elapsed_s']:.2f}s")
+        print(f"    Throughput      : {kafka_result['throughput_eps']:,.0f} events/s")
+        print(f"    Bandwidth       : {kafka_result['throughput_mbps']:.2f} MB/s")
+    else:
+        print("\n  [Live Kafka] broker not reachable — skipping live consumer test.")
+        print("  Set KAFKA_BOOTSTRAP_SERVERS to enable.")
+
+    return results
+
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/benchmarks/flink_job_latency.py
+++ b/benchmarks/flink_job_latency.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+StreamForge AI — Flink Job Latency Benchmark
+
+Measures the end-to-end latency of the StreamForge Flink stream-processing
+pipeline by replaying the same logic that lives in:
+
+    stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java
+
+Stages timed individually:
+  1. Deserialisation   — JSON bytes → CdcEvent (mirrors SchemaAwareCdcDeserializationSchema)
+  2. Filter            — op == "c" guard (mirrors the filter() call in the job)
+  3. Window aggregation — tumbling time-window count (mirrors TumblingEventTimeWindows)
+  4. Serialisation     — WindowResult → JSON bytes (mirrors UserEventCountSerializationSchema)
+
+Because the benchmark is pure Python it cannot exercise real Flink watermark
+scheduling, but the arithmetic and serialisation cost faithfully mirrors the
+Java implementation. The window sizes and out-of-orderness constants are taken
+from the defaults in CdcUserEventCountJob.
+
+Reproducibility
+---------------
+All timestamps are deterministic (seed-driven). Running the benchmark twice
+on the same machine must produce identical event counts (throughput numbers
+may differ by ±5 % due to OS scheduling noise).
+"""
+
+import json
+import random
+import statistics
+import time
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+RANDOM_SEED = 42
+random.seed(RANDOM_SEED)
+
+# ---------------------------------------------------------------------------
+# Data models (Python equivalents of the Java model classes)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CdcEvent:
+    op: str                  # "c" insert, "u" update, "d" delete, "r" snapshot
+    ts_ms: int               # Debezium source timestamp (event time)
+    customer_id: int
+    schema_version: int = 1
+
+
+@dataclass
+class WindowResult:
+    window_start_ms: int
+    window_end_ms: int
+    user_id: int
+    event_count: int
+    emitted_at_ms: int
+
+
+# ---------------------------------------------------------------------------
+# Pipeline stages (Python mirrors of the Java operators)
+# ---------------------------------------------------------------------------
+
+def _deserialise(raw: bytes) -> CdcEvent:
+    d = json.loads(raw)
+    payload = d["payload"]
+    after = payload.get("after") or {}
+    return CdcEvent(
+        op=payload["op"],
+        ts_ms=payload["ts_ms"],
+        customer_id=after.get("id", -1),
+        schema_version=d["schema"].get("version", 1),
+    )
+
+
+def _filter_insert(event: CdcEvent) -> bool:
+    return event.op == "c" and event.schema_version == 1
+
+
+def _aggregate_window(events: List[CdcEvent], window_start_ms: int,
+                      window_size_ms: int) -> List[WindowResult]:
+    counts: Dict[int, int] = {}
+    for e in events:
+        counts[e.customer_id] = counts.get(e.customer_id, 0) + 1
+    now_ms = int(time.time() * 1000)
+    return [
+        WindowResult(
+            window_start_ms=window_start_ms,
+            window_end_ms=window_start_ms + window_size_ms,
+            user_id=uid,
+            event_count=cnt,
+            emitted_at_ms=now_ms,
+        )
+        for uid, cnt in counts.items()
+    ]
+
+
+def _serialise(result: WindowResult) -> bytes:
+    return json.dumps({
+        "window_start": result.window_start_ms,
+        "window_end": result.window_end_ms,
+        "user_id": result.user_id,
+        "event_count": result.event_count,
+        "emitted_at": result.emitted_at_ms,
+    }).encode()
+
+
+# ---------------------------------------------------------------------------
+# Event generator
+# ---------------------------------------------------------------------------
+
+def _make_raw_event(seq: int, base_ts_ms: int, rng: random.Random,
+                    insert_ratio: float = 0.9) -> bytes:
+    op = "c" if rng.random() < insert_ratio else rng.choice(["u", "d"])
+    customer_id = rng.randint(1, 200)
+    after = {"id": customer_id, "name": f"user_{customer_id}",
+             "email": f"u{customer_id}@example.com"} if op != "d" else None
+    before = {"id": customer_id} if op in ("u", "d") else None
+    ts_ms = base_ts_ms + seq * 10  # 10ms between events
+    envelope = {
+        "schema": {"type": "struct", "version": 1},
+        "payload": {
+            "before": before,
+            "after": after,
+            "op": op,
+            "ts_ms": ts_ms,
+            "source": {"connector": "mysql", "db": "streamforge", "table": "customers"},
+        },
+    }
+    return json.dumps(envelope).encode()
+
+
+def _build_event_stream(num_events: int, base_ts_ms: int,
+                        insert_ratio: float = 0.9) -> List[bytes]:
+    rng = random.Random(RANDOM_SEED)
+    return [_make_raw_event(i, base_ts_ms, rng, insert_ratio) for i in range(num_events)]
+
+
+# ---------------------------------------------------------------------------
+# Scenario definitions
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FlinkScenarioConfig:
+    name: str
+    num_events: int          # events in the stream
+    window_size_s: int       # tumbling window size (seconds); matches WINDOW_SIZE_SECONDS env var
+    insert_ratio: float = 0.9
+    out_of_orderness_s: int = 5  # matches OUT_OF_ORDERNESS_SECONDS env var
+    repeat: int = 5
+
+
+@dataclass
+class FlinkBenchmarkResult:
+    scenario: str
+    num_events: int
+    windows_fired: int
+    deser_ms: float          # total deserialisation time
+    filter_ms: float         # total filter time
+    window_ms: float         # total window aggregation time
+    ser_ms: float            # total serialisation time
+    e2e_ms: float            # total end-to-end pipeline time
+    throughput_eps: float    # events processed per second (e2e)
+    avg_window_latency_ms: float  # average per-window processing time
+
+
+SCENARIOS: List[FlinkScenarioConfig] = [
+    FlinkScenarioConfig("Small stream   (1k events,  30s window)",
+                        num_events=1_000,  window_size_s=30),
+    FlinkScenarioConfig("Medium stream  (10k events, 30s window)",
+                        num_events=10_000, window_size_s=30),
+    FlinkScenarioConfig("Large stream   (50k events, 30s window)",
+                        num_events=50_000, window_size_s=30),
+    FlinkScenarioConfig("Wide window    (10k events, 60s window)",
+                        num_events=10_000, window_size_s=60),
+    FlinkScenarioConfig("Narrow window  (10k events, 10s window)",
+                        num_events=10_000, window_size_s=10),
+    FlinkScenarioConfig("Low insert ratio (10k events, 30% INSERT)",
+                        num_events=10_000, window_size_s=30, insert_ratio=0.3),
+]
+
+
+# ---------------------------------------------------------------------------
+# Benchmark execution
+# ---------------------------------------------------------------------------
+
+def _run_pipeline(raw_events: List[bytes], window_size_ms: int) -> Tuple[
+        float, float, float, float, int, List[float]]:
+    """
+    Run all four pipeline stages and return:
+    (deser_ms, filter_ms, window_ms, ser_ms, windows_fired, per_window_latencies_ms)
+    """
+    # Stage 1 — Deserialisation
+    t0 = time.perf_counter()
+    events = [_deserialise(r) for r in raw_events]
+    deser_ms = (time.perf_counter() - t0) * 1000
+
+    # Stage 2 — Filter (INSERT + schema check)
+    t1 = time.perf_counter()
+    inserts = [e for e in events if _filter_insert(e)]
+    filter_ms = (time.perf_counter() - t1) * 1000
+
+    # Stage 3 — Tumbling window aggregation
+    # Group events into windows by their ts_ms
+    t2 = time.perf_counter()
+    window_groups: Dict[int, List[CdcEvent]] = {}
+    if inserts:
+        min_ts = min(e.ts_ms for e in inserts)
+        for e in inserts:
+            bucket = ((e.ts_ms - min_ts) // window_size_ms) * window_size_ms + min_ts
+            window_groups.setdefault(bucket, []).append(e)
+
+    per_window_latencies: List[float] = []
+    all_results: List[WindowResult] = []
+    for ws, evs in window_groups.items():
+        wt0 = time.perf_counter()
+        results = _aggregate_window(evs, ws, window_size_ms)
+        per_window_latencies.append((time.perf_counter() - wt0) * 1000)
+        all_results.extend(results)
+    window_ms = (time.perf_counter() - t2) * 1000
+
+    # Stage 4 — Serialisation
+    t3 = time.perf_counter()
+    for r in all_results:
+        _serialise(r)
+    ser_ms = (time.perf_counter() - t3) * 1000
+
+    return deser_ms, filter_ms, window_ms, ser_ms, len(window_groups), per_window_latencies
+
+
+def run_scenario(cfg: FlinkScenarioConfig) -> FlinkBenchmarkResult:
+    base_ts_ms = 1_700_000_000_000  # fixed epoch for reproducibility
+    raw_events = _build_event_stream(cfg.num_events, base_ts_ms, cfg.insert_ratio)
+    window_size_ms = cfg.window_size_s * 1000
+
+    agg: Dict[str, List[float]] = {k: [] for k in
+                                    ["deser", "filt", "win", "ser", "e2e", "wlat"]}
+    windows_fired_runs: List[int] = []
+
+    for _ in range(cfg.repeat):
+        t_start = time.perf_counter()
+        deser, filt, win, ser, nw, wlats = _run_pipeline(raw_events, window_size_ms)
+        e2e = (time.perf_counter() - t_start) * 1000
+        agg["deser"].append(deser)
+        agg["filt"].append(filt)
+        agg["win"].append(win)
+        agg["ser"].append(ser)
+        agg["e2e"].append(e2e)
+        agg["wlat"].extend(wlats)
+        windows_fired_runs.append(nw)
+
+    avg_e2e_ms = statistics.mean(agg["e2e"])
+    avg_wlat = statistics.mean(agg["wlat"]) if agg["wlat"] else 0.0
+
+    return FlinkBenchmarkResult(
+        scenario=cfg.name,
+        num_events=cfg.num_events,
+        windows_fired=round(statistics.mean(windows_fired_runs)),
+        deser_ms=statistics.mean(agg["deser"]),
+        filter_ms=statistics.mean(agg["filt"]),
+        window_ms=statistics.mean(agg["win"]),
+        ser_ms=statistics.mean(agg["ser"]),
+        e2e_ms=avg_e2e_ms,
+        throughput_eps=cfg.num_events / (avg_e2e_ms / 1000),
+        avg_window_latency_ms=avg_wlat,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def _print_results(results: List[FlinkBenchmarkResult]) -> None:
+    w = 100
+    print("\n" + "=" * w)
+    print("            StreamForge AI: Flink Job Latency Benchmark Results")
+    print("=" * w)
+    hdr = (f"{'Scenario':<45} {'E2E ms':>8} {'Deser ms':>9} {'Win ms':>7} "
+           f"{'Ser ms':>7} {'Win/s':>6} {'Events/s':>10}")
+    print(hdr)
+    print("-" * w)
+    for r in results:
+        print(
+            f"{r.scenario:<45} {r.e2e_ms:>8.1f} {r.deser_ms:>9.1f} {r.window_ms:>7.1f}"
+            f" {r.ser_ms:>7.1f} {r.windows_fired:>6} {r.throughput_eps:>10,.0f}"
+        )
+    print("=" * w)
+    print("  E2E ms   = total pipeline latency for the full event stream (ms)")
+    print("  Deser ms = deserialisation stage time")
+    print("  Win ms   = window aggregation stage time (grouping + counting)")
+    print("  Ser ms   = serialisation stage time (WindowResult → JSON bytes)")
+    print("  Win/s    = number of tumbling windows fired")
+    print("  Events/s = end-to-end throughput")
+    print()
+    print("  Stage breakdown (average across scenarios):")
+    avg_e2e = statistics.mean(r.e2e_ms for r in results)
+    avg_deser = statistics.mean(r.deser_ms for r in results)
+    avg_win = statistics.mean(r.window_ms for r in results)
+    avg_ser = statistics.mean(r.ser_ms for r in results)
+    print(f"    Deserialisation : {avg_deser / avg_e2e * 100:5.1f}% of E2E")
+    print(f"    Window agg      : {avg_win   / avg_e2e * 100:5.1f}% of E2E")
+    print(f"    Serialisation   : {avg_ser   / avg_e2e * 100:5.1f}% of E2E")
+    print("=" * w)
+
+
+def run_benchmark() -> List[FlinkBenchmarkResult]:
+    print("=" * 70)
+    print("      StreamForge AI: Flink Job — Latency Benchmark")
+    print("=" * 70)
+    print(f"  Seed: {RANDOM_SEED}  |  Scenarios: {len(SCENARIOS)}")
+    print("  (Pure-Python replay of CdcUserEventCountJob pipeline stages)\n")
+
+    results = []
+    for i, cfg in enumerate(SCENARIOS, 1):
+        print(f"  [{i}/{len(SCENARIOS)}] {cfg.name} ...", end=" ", flush=True)
+        r = run_scenario(cfg)
+        results.append(r)
+        print(f"done  (e2e={r.e2e_ms:.1f}ms, {r.throughput_eps:,.0f} events/s)")
+
+    _print_results(results)
+    return results
+
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/benchmarks/minio_write_throughput.py
+++ b/benchmarks/minio_write_throughput.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+"""
+StreamForge AI — MinIO Write Throughput Benchmark
+
+Measures write throughput to MinIO (S3-compatible object storage) across
+different object sizes and concurrency levels, mirroring the access patterns
+used by the feature-sink service in:
+
+    deploy/cdc-flink-minio-demo/feature-sink/feature_to_minio.py
+
+Two execution modes
+-------------------
+1. **Live MinIO** — if a MinIO instance is reachable (configured via env vars
+   or defaults matching deploy/cdc-flink-minio-demo/docker-compose.yml) the
+   benchmark writes real objects and measures actual S3 PUT latency.
+
+2. **Local-filesystem simulation** — when MinIO is unavailable the benchmark
+   writes to a temporary directory and measures filesystem write throughput,
+   providing a reproducible lower-bound reference that runs in CI/CD with no
+   external dependencies.
+
+Environment variables (matching feature-sink and prefetch-engine conventions)
+-----------------------------------------------------------------------------
+  MINIO_ENDPOINT    — default: localhost:9000
+  MINIO_ACCESS_KEY  — default: minioadmin
+  MINIO_SECRET_KEY  — default: minioadmin
+  MINIO_SECURE      — default: false
+  MINIO_BUCKET      — default: processed
+  MINIO_PREFIX      — default: benchmarks
+"""
+
+import io
+import json
+import os
+import random
+import statistics
+import tempfile
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Callable, Tuple
+
+RANDOM_SEED = 42
+random.seed(RANDOM_SEED)
+
+# ---------------------------------------------------------------------------
+# Payload generators
+# ---------------------------------------------------------------------------
+
+def _make_json_payload(size_bytes: int) -> bytes:
+    """Generate a realistic feature-sink JSON payload of approximately size_bytes."""
+    base = {
+        "job_id": "bench-" + str(random.randint(100000, 999999)),
+        "window_start": 1700000000000,
+        "window_end":   1700000060000,
+        "user_id": random.randint(1, 10000),
+        "event_count": random.randint(1, 500),
+        "sink_timestamp": int(time.time() * 1000),
+        "pipeline": "cdc-flink-minio",
+    }
+    base_bytes = json.dumps(base).encode()
+    # Pad with a repeated "padding" field to reach target size
+    if len(base_bytes) < size_bytes:
+        padding = "x" * (size_bytes - len(base_bytes) - 15)
+        base["_pad"] = padding
+    return json.dumps(base).encode()
+
+
+def _make_binary_payload(size_bytes: int) -> bytes:
+    rng = random.Random(RANDOM_SEED)
+    return bytes(rng.getrandbits(8) for _ in range(size_bytes))
+
+
+# ---------------------------------------------------------------------------
+# Backend abstraction
+# ---------------------------------------------------------------------------
+
+class _MinioBackend:
+    def __init__(self, client, bucket: str, prefix: str):
+        self._client = client
+        self._bucket = bucket
+        self._prefix = prefix
+
+    def write(self, key: str, data: bytes) -> float:
+        t0 = time.perf_counter()
+        self._client.put_object(
+            self._bucket,
+            f"{self._prefix}/{key}",
+            io.BytesIO(data),
+            length=len(data),
+            content_type="application/json",
+        )
+        return time.perf_counter() - t0
+
+    def cleanup(self, keys: List[str]) -> None:
+        from minio.deleteobjects import DeleteObject  # type: ignore
+        objects = [DeleteObject(f"{self._prefix}/{k}") for k in keys]
+        errors = list(self._client.remove_objects(self._bucket, objects))
+        _ = errors  # best-effort cleanup
+
+
+class _FilesystemBackend:
+    def __init__(self, base_dir: Path):
+        self._base = base_dir
+        self._base.mkdir(parents=True, exist_ok=True)
+
+    def write(self, key: str, data: bytes) -> float:
+        path = self._base / key.replace("/", "_")
+        t0 = time.perf_counter()
+        path.write_bytes(data)
+        return time.perf_counter() - t0
+
+    def cleanup(self, keys: List[str]) -> None:
+        for key in keys:
+            p = self._base / key.replace("/", "_")
+            p.unlink(missing_ok=True)
+
+
+def _resolve_backend(tmp_dir: Path) -> Tuple[object, str]:
+    endpoint  = os.environ.get("MINIO_ENDPOINT",   "localhost:9000")
+    access    = os.environ.get("MINIO_ACCESS_KEY", "minioadmin")
+    secret    = os.environ.get("MINIO_SECRET_KEY", "minioadmin")
+    secure    = os.environ.get("MINIO_SECURE",     "false").lower() == "true"
+    bucket    = os.environ.get("MINIO_BUCKET",     "processed")
+    prefix    = os.environ.get("MINIO_PREFIX",     "benchmarks")
+
+    try:
+        from minio import Minio  # type: ignore
+        client = Minio(endpoint, access_key=access, secret_key=secret, secure=secure)
+        # Quick connectivity check
+        client.list_buckets()
+        if not client.bucket_exists(bucket):
+            client.make_bucket(bucket)
+        return _MinioBackend(client, bucket, prefix), "minio"
+    except Exception:
+        pass
+
+    return _FilesystemBackend(tmp_dir / "minio_sim"), "filesystem"
+
+
+# ---------------------------------------------------------------------------
+# Scenario definitions
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MinioScenarioConfig:
+    name: str
+    object_size_bytes: int
+    num_objects: int
+    concurrency: int = 1    # parallel writer threads
+    repeat: int = 3
+
+
+@dataclass
+class MinioBenchmarkResult:
+    scenario: str
+    backend: str            # "minio" or "filesystem"
+    object_size_bytes: int
+    num_objects: int
+    concurrency: int
+    throughput_ops: float   # objects per second
+    throughput_mbs: float   # MB per second
+    p50_ms: float           # median PUT latency (ms)
+    p99_ms: float           # 99th-percentile PUT latency (ms)
+    total_s: float
+
+
+SCENARIOS: List[MinioScenarioConfig] = [
+    MinioScenarioConfig("Tiny objects   (1 KB  × 100, concurrency=1)",
+                        object_size_bytes=1_024,        num_objects=100, concurrency=1),
+    MinioScenarioConfig("Small objects  (10 KB × 100, concurrency=1)",
+                        object_size_bytes=10_240,       num_objects=100, concurrency=1),
+    MinioScenarioConfig("Medium objects (100 KB× 50,  concurrency=1)",
+                        object_size_bytes=102_400,      num_objects=50,  concurrency=1),
+    MinioScenarioConfig("Large objects  (1 MB  × 20,  concurrency=1)",
+                        object_size_bytes=1_048_576,    num_objects=20,  concurrency=1),
+    MinioScenarioConfig("Concurrent     (10 KB × 100, concurrency=4)",
+                        object_size_bytes=10_240,       num_objects=100, concurrency=4),
+    MinioScenarioConfig("Concurrent     (100 KB× 50,  concurrency=4)",
+                        object_size_bytes=102_400,      num_objects=50,  concurrency=4),
+    MinioScenarioConfig("Feature-sink   (2 KB  × 200, concurrency=1)  [realistic]",
+                        object_size_bytes=2_048,        num_objects=200, concurrency=1),
+]
+
+
+# ---------------------------------------------------------------------------
+# Benchmark execution
+# ---------------------------------------------------------------------------
+
+def _run_writes_serial(backend, payloads: List[bytes]) -> List[float]:
+    latencies = []
+    for i, payload in enumerate(payloads):
+        key = f"obj_{i:06d}_{int(time.time()*1000)}.json"
+        lat = backend.write(key, payload)
+        latencies.append(lat)
+    return latencies
+
+
+def _run_writes_concurrent(backend, payloads: List[bytes],
+                           concurrency: int) -> List[float]:
+    latencies: List[float] = []
+    lock = threading.Lock()
+    chunks = [payloads[i::concurrency] for i in range(concurrency)]
+
+    def worker(chunk: List[bytes], thread_id: int) -> None:
+        for j, payload in enumerate(chunk):
+            key = f"obj_t{thread_id}_{j:06d}_{int(time.time()*1000)}.json"
+            lat = backend.write(key, payload)
+            with lock:
+                latencies.append(lat)
+
+    threads = [threading.Thread(target=worker, args=(chunk, tid))
+               for tid, chunk in enumerate(chunks)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return latencies
+
+
+def run_scenario(cfg: MinioScenarioConfig, backend, backend_name: str,
+                 repeat: int = 3) -> MinioBenchmarkResult:
+    rng = random.Random(RANDOM_SEED)
+    # Use JSON payloads for realistic feature-sink simulation
+    payloads = [_make_json_payload(cfg.object_size_bytes) for _ in range(cfg.num_objects)]
+
+    all_lats: List[float] = []
+    all_total_s: List[float] = []
+
+    for _ in range(repeat):
+        t0 = time.perf_counter()
+        if cfg.concurrency > 1:
+            lats = _run_writes_concurrent(backend, payloads, cfg.concurrency)
+        else:
+            lats = _run_writes_serial(backend, payloads)
+        total_s = time.perf_counter() - t0
+        all_lats.extend(lats)
+        all_total_s.append(total_s)
+
+    avg_total_s = statistics.mean(all_total_s)
+    sorted_lats_ms = sorted(l * 1000 for l in all_lats)
+    total_bytes = cfg.object_size_bytes * cfg.num_objects * repeat
+
+    return MinioBenchmarkResult(
+        scenario=cfg.name,
+        backend=backend_name,
+        object_size_bytes=cfg.object_size_bytes,
+        num_objects=cfg.num_objects,
+        concurrency=cfg.concurrency,
+        throughput_ops=cfg.num_objects / avg_total_s,
+        throughput_mbs=total_bytes / avg_total_s / 1e6 / repeat,
+        p50_ms=sorted_lats_ms[len(sorted_lats_ms) // 2],
+        p99_ms=sorted_lats_ms[int(len(sorted_lats_ms) * 0.99)],
+        total_s=avg_total_s,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def _print_results(results: List[MinioBenchmarkResult], backend_name: str) -> None:
+    w = 95
+    print("\n" + "=" * w)
+    mode = "MinIO (live)" if backend_name == "minio" else "Filesystem simulation"
+    print(f"         StreamForge AI: MinIO Write Throughput Results  [{mode}]")
+    print("=" * w)
+    hdr = (f"{'Scenario':<50} {'ops/s':>7} {'MB/s':>7} "
+           f"{'p50 ms':>8} {'p99 ms':>8} {'Total s':>8}")
+    print(hdr)
+    print("-" * w)
+    for r in results:
+        print(
+            f"{r.scenario:<50} {r.throughput_ops:>7.1f} {r.throughput_mbs:>7.2f}"
+            f" {r.p50_ms:>8.2f} {r.p99_ms:>8.2f} {r.total_s:>8.2f}"
+        )
+    print("=" * w)
+    if backend_name == "filesystem":
+        print("  NOTE: Running in filesystem-simulation mode (MinIO not reachable).")
+        print("        Set MINIO_ENDPOINT / MINIO_ACCESS_KEY / MINIO_SECRET_KEY to")
+        print("        run against a live MinIO instance (e.g. deploy/cdc-flink-minio-demo).")
+    print("  ops/s  = PUT objects per second")
+    print("  MB/s   = raw write throughput in megabytes per second")
+    print("  p50/p99 = PUT latency percentiles in milliseconds")
+    print("=" * w)
+
+
+def run_benchmark() -> List[MinioBenchmarkResult]:
+    print("=" * 70)
+    print("      StreamForge AI: MinIO Write — Throughput Benchmark")
+    print("=" * 70)
+    print(f"  Endpoint : {os.environ.get('MINIO_ENDPOINT', 'localhost:9000')}")
+    print(f"  Bucket   : {os.environ.get('MINIO_BUCKET', 'processed')}")
+    print(f"  Scenarios: {len(SCENARIOS)}\n")
+    print("  Detecting backend ...", end=" ", flush=True)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        backend, backend_name = _resolve_backend(tmp_path)
+        print(f"using {backend_name.upper()}\n")
+
+        results = []
+        for i, cfg in enumerate(SCENARIOS, 1):
+            print(f"  [{i}/{len(SCENARIOS)}] {cfg.name} ...", end=" ", flush=True)
+            r = run_scenario(cfg, backend, backend_name, repeat=cfg.repeat)
+            results.append(r)
+            print(f"done  ({r.throughput_ops:.1f} ops/s, {r.throughput_mbs:.2f} MB/s, "
+                  f"p99={r.p99_ms:.1f}ms)")
+
+        _print_results(results, backend_name)
+    return results
+
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/benchmarks/prefetch_cache_hitrate.py
+++ b/benchmarks/prefetch_cache_hitrate.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+StreamForge AI — Prefetch Cache Hit-Ratio vs Cold-Start Time Benchmark
+
+Isolates and quantifies the relationship between the prefetch-engine's
+cache hit-ratio and the ML job cold-start time, sweeping across:
+
+  - Hit-ratio   : 0 %, 25 %, 50 %, 75 %, 100 %
+  - Dataset size: small (10 files), medium (50 files), large (200 files)
+
+Unlike the broader prefetch/benchmark.py (which compares prefetch vs.
+no-prefetch across fixed scenarios), this benchmark answers the specific
+question: "how much does each additional 25 pp of cache coverage reduce
+cold-start latency?"
+
+Metrics reported per (dataset-size, hit-ratio) cell
+----------------------------------------------------
+  cold_start_ms   Total job startup time (time to first processed record)
+  ttfb_ms         Time-to-first-batch  (first window of records ready)
+  hit_ratio       Actual cache hit rate (may differ from target)
+  miss_penalty_ms Average per-miss latency cost (remote I/O penalty)
+  speedup_x       Cold-start speedup vs. 0 % hit-ratio baseline
+
+Reproducibility
+---------------
+File content and hot/cold selection are seeded; latency constants mirror
+the values used in prefetch-engine/benchmark.py so results are directly
+comparable across benchmark runs.
+"""
+
+import os
+import random
+import shutil
+import statistics
+import tempfile
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+RANDOM_SEED = 42
+random.seed(RANDOM_SEED)
+
+# Latency constants (matching prefetch-engine/benchmark.py)
+REMOTE_LATENCY_S = 0.050   # 50ms  — simulated MinIO/S3 round-trip
+LOCAL_LATENCY_S  = 0.002   # 2ms   — simulated local cache/SSD read
+COLD_START_OVERHEAD_S = 0.010  # 10ms — framework init cost (JVM/Python runtime)
+
+
+# ---------------------------------------------------------------------------
+# File helpers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FileMeta:
+    path: Path
+    size_bytes: int
+    is_hot: bool
+
+
+def _create_dataset(base: Path, n_files: int, size_bytes: int,
+                    hot_ratio: float, seed: int = RANDOM_SEED) -> List[_FileMeta]:
+    base.mkdir(parents=True, exist_ok=True)
+    rng = random.Random(seed)
+    files = []
+    for i in range(n_files):
+        p = base / f"part_{i:05d}.bin"
+        p.write_bytes(bytes(rng.getrandbits(8) for _ in range(size_bytes)))
+        files.append(_FileMeta(path=p, size_bytes=size_bytes,
+                               is_hot=i < int(n_files * hot_ratio)))
+    return files
+
+
+def _prefetch_hot(files: List[_FileMeta], cache_dir: Path) -> float:
+    """Copy hot files to cache_dir; return elapsed seconds."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    t0 = time.perf_counter()
+    for f in files:
+        if f.is_hot:
+            time.sleep(REMOTE_LATENCY_S)          # simulate remote read
+            dest = cache_dir / f.path.name
+            shutil.copy2(f.path, dest)            # write to local cache
+    return time.perf_counter() - t0
+
+
+def _simulate_job_run(files: List[_FileMeta], cache_dir: Path) -> Tuple[float, float, int, int]:
+    """
+    Simulate a streaming ML job reading all files.
+    Returns: (cold_start_s, ttfb_s, hits, misses)
+    cold_start_s = time until first record processed
+    ttfb_s       = time until first full batch (all files in first window)
+    """
+    hits = 0
+    misses = 0
+    t_start = time.perf_counter()
+    first_record_t: Optional[float] = None
+
+    # Simulate framework startup overhead
+    time.sleep(COLD_START_OVERHEAD_S)
+
+    for i, f in enumerate(files):
+        cached = (cache_dir / f.path.name).exists()
+        if cached:
+            time.sleep(LOCAL_LATENCY_S)
+            hits += 1
+        else:
+            time.sleep(REMOTE_LATENCY_S + LOCAL_LATENCY_S)
+            misses += 1
+
+        now = time.perf_counter()
+        if first_record_t is None:
+            first_record_t = now  # time to first record
+
+    total_s = time.perf_counter() - t_start
+    ttfb_s = first_record_t - t_start if first_record_t else total_s
+    return total_s, ttfb_s, hits, misses
+
+
+# ---------------------------------------------------------------------------
+# Scenario definitions
+# ---------------------------------------------------------------------------
+
+HIT_RATIOS = [0.0, 0.25, 0.50, 0.75, 1.0]
+
+@dataclass
+class DatasetConfig:
+    label: str
+    n_files: int
+    file_size_bytes: int
+    repeat: int = 3
+
+
+@dataclass
+class HitRatioResult:
+    dataset_label: str
+    hit_ratio_target: float
+    hit_ratio_actual: float
+    cold_start_ms: float
+    ttfb_ms: float
+    miss_penalty_ms: float   # average latency cost per cache miss
+    speedup_x: float         # vs. 0% hit-ratio baseline for same dataset
+    prefetch_overhead_ms: float  # time spent in prefetch phase
+
+
+DATASETS: List[DatasetConfig] = [
+    DatasetConfig("Small  (10 files, 50 KB)", n_files=10,  file_size_bytes=51_200),
+    DatasetConfig("Medium (50 files, 50 KB)", n_files=50,  file_size_bytes=51_200),
+    DatasetConfig("Large  (200 files, 50 KB)", n_files=200, file_size_bytes=51_200),
+]
+
+
+# ---------------------------------------------------------------------------
+# Benchmark execution
+# ---------------------------------------------------------------------------
+
+def run_dataset_sweep(cfg: DatasetConfig,
+                      tmp: Path) -> Dict[float, HitRatioResult]:
+    """Run all hit-ratio points for one dataset config."""
+    results: Dict[float, HitRatioResult] = {}
+    baseline_ms: Optional[float] = None
+
+    for hr in HIT_RATIOS:
+        src_dir   = tmp / f"{cfg.label.replace(' ', '_')}_src"
+        cache_dir = tmp / f"{cfg.label.replace(' ', '_')}_cache_{int(hr*100)}"
+
+        # Rebuild source files (hot flag changes per hr)
+        if src_dir.exists():
+            shutil.rmtree(src_dir)
+        files = _create_dataset(src_dir, cfg.n_files, cfg.file_size_bytes,
+                                hot_ratio=hr)
+
+        all_cold_start: List[float] = []
+        all_ttfb: List[float] = []
+        all_hits: List[int] = []
+        all_misses: List[int] = []
+        all_prefetch: List[float] = []
+
+        for _ in range(cfg.repeat):
+            # Clear cache between runs
+            if cache_dir.exists():
+                shutil.rmtree(cache_dir)
+            prefetch_s = _prefetch_hot(files, cache_dir)
+            cs_s, ttfb_s, hits, misses = _simulate_job_run(files, cache_dir)
+
+            all_cold_start.append(cs_s)
+            all_ttfb.append(ttfb_s)
+            all_hits.append(hits)
+            all_misses.append(misses)
+            all_prefetch.append(prefetch_s)
+
+        avg_cs_ms = statistics.mean(all_cold_start) * 1000
+        avg_ttfb_ms = statistics.mean(all_ttfb) * 1000
+        avg_hits = statistics.mean(all_hits)
+        avg_misses = statistics.mean(all_misses)
+        avg_prefetch_ms = statistics.mean(all_prefetch) * 1000
+
+        actual_hr = avg_hits / cfg.n_files if cfg.n_files > 0 else 0.0
+        miss_penalty = (REMOTE_LATENCY_S * 1000) if avg_misses > 0 else 0.0
+
+        if baseline_ms is None:
+            baseline_ms = avg_cs_ms  # 0% hit-ratio is the baseline
+
+        speedup = baseline_ms / avg_cs_ms if avg_cs_ms > 0 else 1.0
+
+        results[hr] = HitRatioResult(
+            dataset_label=cfg.label,
+            hit_ratio_target=hr,
+            hit_ratio_actual=actual_hr,
+            cold_start_ms=avg_cs_ms,
+            ttfb_ms=avg_ttfb_ms,
+            miss_penalty_ms=miss_penalty,
+            speedup_x=speedup,
+            prefetch_overhead_ms=avg_prefetch_ms,
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def _print_results(all_results: Dict[str, Dict[float, HitRatioResult]]) -> None:
+    w = 105
+    print("\n" + "=" * w)
+    print("      StreamForge AI: Prefetch Cache Hit-Ratio vs Cold-Start Time")
+    print("=" * w)
+
+    for dataset_label, hr_map in all_results.items():
+        print(f"\n  Dataset: {dataset_label}")
+        print(f"  {'Hit Ratio':>10} {'Cold-start ms':>15} {'TTFB ms':>10} "
+              f"{'Speedup':>9} {'Prefetch ms':>13} {'Miss penalty ms':>17}")
+        print("  " + "-" * (w - 2))
+        for hr in HIT_RATIOS:
+            r = hr_map[hr]
+            baseline_marker = "  ← baseline" if hr == 0.0 else ""
+            print(
+                f"  {r.hit_ratio_actual:>9.0%}"
+                f" {r.cold_start_ms:>14.1f}"
+                f" {r.ttfb_ms:>10.1f}"
+                f" {r.speedup_x:>8.2f}×"
+                f" {r.prefetch_overhead_ms:>13.1f}"
+                f" {r.miss_penalty_ms:>16.1f}"
+                f"{baseline_marker}"
+            )
+
+    print("\n" + "=" * w)
+    print("  Hit Ratio    = actual fraction of files served from local cache")
+    print("  Cold-start   = total time (ms) from job start to all files processed")
+    print("  TTFB         = time-to-first-batch: latency to first record read")
+    print("  Speedup      = cold-start improvement vs 0% hit-ratio (same dataset)")
+    print("  Prefetch ms  = time spent copying hot files into local cache")
+    print("  Miss penalty = simulated remote I/O penalty per cache miss (ms)")
+    print()
+
+    # Cross-dataset summary: speedup at 100% hit-ratio
+    print("  100% hit-ratio cold-start speedup by dataset:")
+    for dataset_label, hr_map in all_results.items():
+        r100 = hr_map[1.0]
+        r0   = hr_map[0.0]
+        reduction_pct = (r0.cold_start_ms - r100.cold_start_ms) / r0.cold_start_ms * 100
+        print(f"    {dataset_label:<30}  {r100.speedup_x:.2f}×  "
+              f"({reduction_pct:.1f}% cold-start reduction)")
+    print("=" * w)
+
+
+def run_benchmark() -> Dict[str, Dict[float, HitRatioResult]]:
+    print("=" * 70)
+    print("      StreamForge AI: Prefetch Cache Hit-Ratio vs Cold-Start")
+    print("=" * 70)
+    print(f"  Remote latency : {REMOTE_LATENCY_S*1000:.0f} ms/file")
+    print(f"  Local latency  : {LOCAL_LATENCY_S*1000:.0f} ms/file")
+    print(f"  Startup overhead: {COLD_START_OVERHEAD_S*1000:.0f} ms")
+    print(f"  Hit ratios     : {[f'{h:.0%}' for h in HIT_RATIOS]}")
+    print(f"  Datasets       : {len(DATASETS)}\n")
+
+    all_results: Dict[str, Dict[float, HitRatioResult]] = {}
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp = Path(tmp_dir)
+        for cfg in DATASETS:
+            print(f"  Dataset: {cfg.label}")
+            for hr in HIT_RATIOS:
+                print(f"    hit-ratio={hr:.0%} ...", end=" ", flush=True)
+                # We need to run one at a time; run_dataset_sweep handles all hr for this dataset
+            # Run the full sweep for this dataset
+            hr_map = run_dataset_sweep(cfg, tmp)
+            all_results[cfg.label] = hr_map
+            r0   = hr_map[0.0]
+            r100 = hr_map[1.0]
+            speedup = r100.speedup_x
+            print(f"\r    Completed — 0%→100% hit-ratio speedup: {speedup:.2f}×"
+                  f"  (cold-start: {r0.cold_start_ms:.0f}ms → {r100.cold_start_ms:.0f}ms)")
+
+    _print_results(all_results)
+    return all_results
+
+
+if __name__ == "__main__":
+    run_benchmark()

--- a/benchmarks/run_all.py
+++ b/benchmarks/run_all.py
@@ -5,7 +5,17 @@ StreamForge AI — Master Benchmark Runner
 Runs all component benchmarks and prints a consolidated summary.
 
 Usage:
-    python benchmarks/run_all.py [--component prefetch|rag|workflow]
+    python benchmarks/run_all.py [--component <name>]
+
+Available components
+--------------------
+  prefetch        Prefetch engine multi-scenario benchmark (existing)
+  rag             RAG engine benchmark
+  workflow        Agent-workflow benchmark
+  cdc             CDC ingestion throughput (events/s, parse latency)
+  flink           Flink job latency (pipeline stage breakdown)
+  minio           MinIO write throughput (ops/s, MB/s, PUT latency)
+  cache_hitrate   Prefetch cache hit-ratio vs cold-start time sweep
 """
 import argparse
 import sys
@@ -18,6 +28,16 @@ def _add_to_path(rel: str):
     if str(p) not in sys.path:
         sys.path.insert(0, str(p))
 
+
+def _add_bench_path():
+    p = Path(__file__).parent
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+
+# ---------------------------------------------------------------------------
+# Existing component runners
+# ---------------------------------------------------------------------------
 
 def run_prefetch():
     _add_to_path("prefetch-engine")
@@ -37,10 +57,46 @@ def run_workflow():
     return run_benchmark()
 
 
+# ---------------------------------------------------------------------------
+# New component runners
+# ---------------------------------------------------------------------------
+
+def run_cdc():
+    _add_bench_path()
+    from cdc_ingestion_throughput import run_benchmark
+    return run_benchmark()
+
+
+def run_flink():
+    _add_bench_path()
+    from flink_job_latency import run_benchmark
+    return run_benchmark()
+
+
+def run_minio():
+    _add_bench_path()
+    from minio_write_throughput import run_benchmark
+    return run_benchmark()
+
+
+def run_cache_hitrate():
+    _add_bench_path()
+    from prefetch_cache_hitrate import run_benchmark
+    return run_benchmark()
+
+
+# ---------------------------------------------------------------------------
+# Component registry
+# ---------------------------------------------------------------------------
+
 COMPONENTS = {
-    "prefetch": ("Prefetch Engine", run_prefetch),
-    "rag":      ("RAG Engine",      run_rag),
-    "workflow": ("Agent Workflow",  run_workflow),
+    "prefetch":     ("Prefetch Engine",                 run_prefetch),
+    "rag":          ("RAG Engine",                      run_rag),
+    "workflow":     ("Agent Workflow",                  run_workflow),
+    "cdc":          ("CDC Ingestion Throughput",        run_cdc),
+    "flink":        ("Flink Job Latency",               run_flink),
+    "minio":        ("MinIO Write Throughput",          run_minio),
+    "cache_hitrate":("Prefetch Cache Hit-Ratio",        run_cache_hitrate),
 }
 
 
@@ -54,7 +110,8 @@ def main():
     )
     args = parser.parse_args()
 
-    targets = {args.component: COMPONENTS[args.component]} if args.component else COMPONENTS
+    targets = ({args.component: COMPONENTS[args.component]}
+               if args.component else COMPONENTS)
 
     print("\n" + "=" * 70)
     print("         StreamForge AI — Performance Benchmark Suite")
@@ -81,7 +138,7 @@ def main():
     print("=" * 70)
     for label, elapsed in timings.items():
         status = f"{elapsed:.2f}s" if elapsed is not None else "FAILED"
-        print(f"  {label:<30} {status:>10}")
+        print(f"  {label:<38} {status:>10}")
     print("=" * 70 + "\n")
 
 


### PR DESCRIPTION
…and prefetch cache

Adds four new self-contained benchmark modules under benchmarks/ covering the four performance dimensions called out in the roadmap:

- cdc_ingestion_throughput.py   — parse/filter throughput (events/s) and
  per-event latency (p50/p99 µs) for Debezium CDC envelopes across six
  scenarios including schema-drift and mixed-op workloads; optionally measures
  live Kafka consumer throughput when KAFKA_BOOTSTRAP_SERVERS is set.

- flink_job_latency.py          — end-to-end latency breakdown of the
  CdcUserEventCountJob pipeline (deserialisation → filter → tumbling-window
  aggregation → serialisation) across six window-size / stream-size scenarios.

- minio_write_throughput.py     — PUT throughput (ops/s, MB/s) and latency
  (p50/p99 ms) from 1 KB to 1 MB objects with serial and concurrent writers;
  auto-detects a live MinIO instance, falls back to filesystem simulation so
  the benchmark is always runnable in CI.

- prefetch_cache_hitrate.py     — sweeps cache hit-ratio from 0 % to 100 % in
  25 pp steps across small / medium / large datasets, reporting cold-start ms,
  time-to-first-batch, and speedup vs. the cold baseline.

All benchmarks use RANDOM_SEED=42 for reproducibility, have zero new dependencies (minio SDK already in prefetch-engine/requirements.txt), and are wired into the master runner via run_all.py --component {cdc,flink,minio,cache_hitrate}.