### PR TITLE
feat(examples): end-to-end ML training example with prefetch cache wa…

### DIFF
--- a/examples/ml-training-prefetch/Dockerfile
+++ b/examples/ml-training-prefetch/Dockerfile
@@ -1,0 +1,36 @@
+# StreamForge AI — ML Training + Prefetch Engine
+# Build context must be the repo root so both prefetch-engine/ and
+# examples/ml-training-prefetch/ are available in one layer.
+#
+#   docker build -f examples/ml-training-prefetch/Dockerfile -t streamforge-ml-trainer .
+
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# ── System dependencies ───────────────────────────────────────────────────────
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Python dependencies ───────────────────────────────────────────────────────
+# Copy requirements first to benefit from Docker layer caching
+COPY prefetch-engine/requirements.txt /tmp/prefetch-requirements.txt
+COPY examples/ml-training-prefetch/requirements.txt /tmp/example-requirements.txt
+
+RUN pip install --no-cache-dir \
+    -r /tmp/prefetch-requirements.txt \
+    -r /tmp/example-requirements.txt
+
+# ── Application code ──────────────────────────────────────────────────────────
+# prefetch-engine source (pipeline imports from it directly)
+COPY prefetch-engine/ /app/prefetch-engine/
+
+# The ML training example
+COPY examples/ml-training-prefetch/ /app/examples/ml-training-prefetch/
+
+# Make the example importable without an install step
+ENV PYTHONPATH=/app/prefetch-engine:/app/examples/ml-training-prefetch
+
+# Default entrypoint — can be overridden by docker compose command
+ENTRYPOINT ["python", "examples/ml-training-prefetch/pipeline.py"]

--- a/examples/ml-training-prefetch/README.md
+++ b/examples/ml-training-prefetch/README.md
@@ -1,0 +1,153 @@
+# ML Training with Prefetch Cache Warm-up
+
+End-to-end example that wires the StreamForge AI data pipeline to a sample
+ML training job, using `prefetch-engine/` to warm the local cache before
+training begins.
+
+## Data flow
+
+```
+MySQL (binlog)
+  │
+  ▼  Debezium CDC
+Kafka  streamforge.streamforge.customers
+  │
+  ▼  Flink CdcUserEventCountJob (30-second tumbling windows)
+Kafka  streamforge.features.user_event_counts
+  │
+  ▼  feature-sink (Kafka → MinIO)
+MinIO  processed/streamforge/features/YYYY/MM/DD/*.json
+  │
+  ▼  feature_store.list_minio_feature_files()
+FileStat manifest  (uri, recent_access_count, last_access_epoch)
+  │
+  ▼  prefetch_warmer.warm_cache()   ← prefetch-engine integration
+Local cache  /tmp/streamforge-demo/prefetch-cache/ml-training/
+  │
+  ▼  feature_store.read_feature_records_from_cache()
+FeatureRecord list  (user_id, window_start_ms, event_count, …)
+  │
+  ▼  trainer.train()
+Classifier (RandomForest or pure-Python LogisticRegression)
+  │
+  ▼  MinIO upload
+MinIO  processed/streamforge/models/<job_id>/model.pkl
+```
+
+## Quick start — no external services
+
+```bash
+# From repo root
+pip install -r prefetch-engine/requirements.txt
+pip install -r examples/ml-training-prefetch/requirements.txt
+
+python examples/ml-training-prefetch/pipeline.py
+```
+
+The pipeline auto-detects that MinIO is not reachable, generates 2 000
+synthetic feature records, warms a local cache, trains a classifier, and
+prints a timing report.
+
+## Against the running demo stack
+
+Start the full `deploy/cdc-flink-minio-demo/` stack, insert rows into MySQL,
+submit the Flink job, and then run the ML trainer against live MinIO data:
+
+```bash
+# 1 — bring up the demo stack
+cd deploy/cdc-flink-minio-demo
+docker compose up -d
+
+# 2 — register the Debezium connector
+curl -X POST -H 'Content-Type: application/json' \
+  --data @connector-config.json http://localhost:8083/connectors
+
+# 3 — submit the Flink job
+docker compose exec jobmanager flink run -d \
+  /opt/flink/usrlib/stream-processor-0.1.0-SNAPSHOT.jar \
+  --bootstrap.servers kafka:9092 \
+  --input.topic streamforge.streamforge.customers \
+  --output.topic streamforge.features.user_event_counts \
+  --window.seconds 30
+
+# 4 — insert some rows (triggers CDC events)
+docker compose exec mysql mysql -udebezium -pdebezium streamforge \
+  -e "INSERT INTO customers (name, email) VALUES ('Alice', 'alice@example.com')"
+
+# 5 — wait ~30 s for the Flink window to fire, then run training
+MINIO_ENDPOINT=localhost:9000 \
+MINIO_ACCESS_KEY=minioadmin   \
+MINIO_SECRET_KEY=minioadmin   \
+python examples/ml-training-prefetch/pipeline.py
+```
+
+## Via Docker Compose (ml-trainer service)
+
+```bash
+# Full pipeline (extends the demo stack)
+docker compose \
+  -f deploy/cdc-flink-minio-demo/docker-compose.yml \
+  -f examples/ml-training-prefetch/docker-compose.yml \
+  up
+
+# Standalone (synthetic features, no upstream pipeline needed)
+cd examples/ml-training-prefetch
+docker compose --profile standalone up
+```
+
+## With Iceberg
+
+When `pyiceberg` is installed and the Iceberg REST catalog is reachable,
+the pipeline reads features directly from the Iceberg table instead of
+raw MinIO JSON files:
+
+```bash
+pip install pyiceberg>=0.6.0
+
+ICEBERG_CATALOG_URI=http://localhost:8181 \
+MINIO_ENDPOINT=localhost:9000             \
+python examples/ml-training-prefetch/pipeline.py
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MINIO_ENDPOINT` | `localhost:9000` | MinIO host:port |
+| `MINIO_ACCESS_KEY` | `minioadmin` | |
+| `MINIO_SECRET_KEY` | `minioadmin` | |
+| `MINIO_BUCKET` | `processed` | Feature bucket |
+| `MINIO_PREFIX` | `streamforge/features` | Feature object prefix |
+| `ICEBERG_CATALOG_URI` | _(unset)_ | REST catalog URL; skipped if empty |
+| `ICEBERG_TABLE` | `streamforge.features.user_event_counts` | |
+| `PREFETCH_TOP_N` | `50` | Hot files staged before training |
+| `PREFETCH_LATENCY_S` | `0.0` | Simulated per-file prefetch RTT (s) |
+| `STREAMFORGE_DEMO_DIR` | `/tmp/streamforge-demo` | Base dir for cache + models |
+| `STREAMFORGE_JOB_ID` | _(timestamp)_ | Job identifier |
+| `N_SYNTHETIC_RECORDS` | `2000` | Synthetic records when offline |
+| `METRICS_PUSHGATEWAY_URL` | _(unset)_ | Prometheus push gateway |
+
+## Module structure
+
+```
+examples/ml-training-prefetch/
+├── pipeline.py          # Main orchestrator — run this
+├── feature_store.py     # MinIO / Iceberg feature discovery + reading
+├── prefetch_warmer.py   # Bridge: prefetch-engine ↔ feature pipeline
+├── trainer.py           # ML dataset prep + model training + MinIO upload
+├── Dockerfile           # Image for docker compose
+├── docker-compose.yml   # ml-trainer service + standalone MinIO profile
+└── requirements.txt     # Optional deps (scikit-learn, pyiceberg)
+```
+
+## Dependencies
+
+| Package | Required | Purpose |
+|---------|----------|---------|
+| `minio` | Yes (in `prefetch-engine/requirements.txt`) | MinIO client |
+| `prometheus_client` | Yes (in `prefetch-engine/requirements.txt`) | Metrics |
+| `scikit-learn` | Optional | RandomForest model (falls back to pure-Python LR) |
+| `pyiceberg` | Optional | Iceberg table reads (falls back to MinIO JSON) |
+
+The example is fully runnable with zero extra installations beyond what
+`prefetch-engine/requirements.txt` already requires.

--- a/examples/ml-training-prefetch/docker-compose.yml
+++ b/examples/ml-training-prefetch/docker-compose.yml
@@ -1,0 +1,101 @@
+# StreamForge AI — ML Training with Prefetch Cache
+#
+# Extends the full demo stack at deploy/cdc-flink-minio-demo/docker-compose.yml
+# with an ml-trainer service that:
+#   1. Waits for the feature-sink to write data to MinIO
+#   2. Runs the prefetch warm-up phase (prefetch-engine)
+#   3. Trains a user-activity classifier on the cached features
+#   4. Uploads the model artifact back to MinIO
+#
+# Usage
+# -----
+#   # Start the full pipeline (CDC → Flink → MinIO → ML training):
+#   docker compose \
+#     -f deploy/cdc-flink-minio-demo/docker-compose.yml \
+#     -f examples/ml-training-prefetch/docker-compose.yml \
+#     up
+#
+#   # Standalone (no upstream pipeline — uses synthetic features):
+#   docker compose up ml-trainer
+#
+# Services added
+# --------------
+#   ml-trainer    Runs pipeline.py once and exits (restart: on-failure)
+#   minio-model   Read-only MinIO alias for inspecting uploaded models
+
+services:
+
+  # ── Standalone MinIO (only started when not using the demo stack) ─────────
+  minio:
+    image: minio/minio:RELEASE.2024-02-09T21-25-16Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    profiles:
+      - standalone      # only started with --profile standalone
+
+  minio-init:
+    image: minio/mc:RELEASE.2024-02-09T16-22-09Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      until /usr/bin/mc alias set local http://minio:9000 minioadmin minioadmin; do sleep 1; done;
+      /usr/bin/mc mb -p local/processed || true;
+      /usr/bin/mc anonymous set download local/processed || true;
+      echo 'MinIO ready.'
+      "
+    profiles:
+      - standalone
+
+  # ── ML Trainer ────────────────────────────────────────────────────────────
+  ml-trainer:
+    build:
+      context: ../../                        # repo root so we can COPY prefetch-engine/
+      dockerfile: examples/ml-training-prefetch/Dockerfile
+    restart: on-failure
+    environment:
+      # MinIO — matches deploy/cdc-flink-minio-demo defaults
+      MINIO_ENDPOINT: ${MINIO_ENDPOINT:-minio:9000}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minioadmin}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin}
+      MINIO_BUCKET: ${MINIO_BUCKET:-processed}
+      MINIO_PREFIX: ${MINIO_PREFIX:-streamforge/features}
+      MINIO_SECURE: ${MINIO_SECURE:-false}
+
+      # Iceberg (optional — leave unset to use MinIO raw files)
+      ICEBERG_CATALOG_URI: ${ICEBERG_CATALOG_URI:-}
+      ICEBERG_TABLE: ${ICEBERG_TABLE:-streamforge.features.user_event_counts}
+
+      # Prefetch tuning
+      PREFETCH_TOP_N: ${PREFETCH_TOP_N:-50}
+      PREFETCH_LATENCY_S: ${PREFETCH_LATENCY_S:-0.0}
+      STREAMFORGE_DEMO_DIR: /tmp/streamforge-demo
+
+      # Training
+      STREAMFORGE_JOB_ID: ${STREAMFORGE_JOB_ID:-}
+      N_SYNTHETIC_RECORDS: ${N_SYNTHETIC_RECORDS:-2000}
+
+      # Prometheus (optional push gateway)
+      METRICS_PUSHGATEWAY_URL: ${METRICS_PUSHGATEWAY_URL:-}
+    volumes:
+      - ml-cache:/tmp/streamforge-demo
+    command: >
+      python examples/ml-training-prefetch/pipeline.py
+        --top-n ${PREFETCH_TOP_N:-50}
+        --latency ${PREFETCH_LATENCY_S:-0.0}
+        --synthetic ${N_SYNTHETIC_RECORDS:-2000}
+
+volumes:
+  ml-cache:
+    driver: local

--- a/examples/ml-training-prefetch/feature_store.py
+++ b/examples/ml-training-prefetch/feature_store.py
@@ -1,0 +1,325 @@
+"""
+Feature Store — MinIO / Iceberg reader for the ML training pipeline.
+
+Responsibilities
+----------------
+1. Discover feature files written by the Flink feature-sink service
+   (bucket: processed, prefix: streamforge/features/**/*.json).
+2. Build a FileStat manifest so the prefetch-engine can score and rank files.
+3. Read feature records from the local cache into Python dicts.
+4. Fall back to generating synthetic feature data when MinIO is unreachable,
+   so the end-to-end example always runs without external services.
+
+Iceberg support
+---------------
+When ``pyiceberg`` is installed and ICEBERG_CATALOG_URI is set, feature files
+are read via the Iceberg REST catalog instead of raw MinIO object listing.
+Both paths produce identical FeatureRecord objects.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import random
+import time
+from dataclasses import dataclass, field
+from io import BytesIO
+from pathlib import Path
+from typing import Iterator, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Public data models
+# ---------------------------------------------------------------------------
+
+@dataclass
+class FeatureRecord:
+    """One aggregated feature row produced by the Flink window."""
+    user_id: int
+    window_start_ms: int
+    window_end_ms: int
+    event_count: int
+    sink_received_at: str = ""
+
+    # Derived convenience helpers
+    @property
+    def window_duration_s(self) -> float:
+        return (self.window_end_ms - self.window_start_ms) / 1000.0
+
+    @property
+    def event_rate(self) -> float:
+        d = self.window_duration_s
+        return self.event_count / d if d > 0 else 0.0
+
+
+@dataclass
+class FileStat:
+    """Access statistics for a single feature file — consumed by prefetch-engine."""
+    uri: str               # "minio://bucket/key" or "file:///abs/path"
+    recent_access_count: int
+    last_access_epoch: float
+
+    @property
+    def score(self) -> float:
+        return float(self.recent_access_count) + 0.000001 * self.last_access_epoch
+
+
+# ---------------------------------------------------------------------------
+# MinIO feature-file discovery
+# ---------------------------------------------------------------------------
+
+def _minio_client():
+    """Return a configured Minio client or None if env vars are absent."""
+    endpoint   = os.environ.get("MINIO_ENDPOINT",   "localhost:9000")
+    access_key = os.environ.get("MINIO_ACCESS_KEY", "minioadmin")
+    secret_key = os.environ.get("MINIO_SECRET_KEY", "minioadmin")
+    secure     = os.environ.get("MINIO_SECURE", "false").lower() == "true"
+    try:
+        from minio import Minio  # type: ignore
+        client = Minio(endpoint, access_key=access_key,
+                       secret_key=secret_key, secure=secure)
+        client.list_buckets()   # connectivity check
+        return client
+    except Exception:
+        return None
+
+
+def list_minio_feature_files(
+    bucket: str = "processed",
+    prefix: str = "streamforge/features",
+    max_files: int = 500,
+) -> Tuple[List[FileStat], bool]:
+    """
+    List feature objects in MinIO and build a FileStat manifest.
+
+    Returns (file_stats, is_live) where is_live=False means synthetic data
+    was generated because MinIO was unreachable.
+    """
+    client = _minio_client()
+    if client is None:
+        return _synthetic_file_stats(max_files), False
+
+    now = time.time()
+    stats: List[FileStat] = []
+    try:
+        objects = client.list_objects(bucket, prefix=prefix, recursive=True)
+        for i, obj in enumerate(objects):
+            if i >= max_files:
+                break
+            # Heuristic access count: newer objects are accessed more
+            age_s = (now - obj.last_modified.timestamp()) if obj.last_modified else 3600
+            access_count = max(1, int(100 / (1 + age_s / 3600)))
+            stats.append(FileStat(
+                uri=f"minio://{bucket}/{obj.object_name}",
+                recent_access_count=access_count,
+                last_access_epoch=obj.last_modified.timestamp() if obj.last_modified else now,
+            ))
+    except Exception:
+        return _synthetic_file_stats(max_files), False
+
+    if not stats:
+        # Bucket exists but no features written yet
+        return _synthetic_file_stats(max_files), False
+
+    return stats, True
+
+
+def _synthetic_file_stats(n: int) -> List[FileStat]:
+    """Produce a realistic FileStat manifest without a real MinIO instance."""
+    rng = random.Random(42)
+    now = time.time()
+    stats = []
+    for i in range(n):
+        age_s = rng.uniform(0, 86400)
+        stats.append(FileStat(
+            uri=f"synthetic://features/part_{i:05d}.json",
+            recent_access_count=rng.randint(1, 120),
+            last_access_epoch=now - age_s,
+        ))
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Feature record reading
+# ---------------------------------------------------------------------------
+
+def read_feature_records_from_cache(
+    cache_dir: Path,
+    file_stats: List[FileStat],
+) -> List[FeatureRecord]:
+    """
+    Read FeatureRecord objects from files already staged in ``cache_dir``.
+
+    Each file is either:
+    - A single JSON object  {"user_id":…, "event_count":…, …}
+    - NDJSON (one JSON per line)
+    Files that cannot be parsed are skipped with a warning.
+    """
+    records: List[FeatureRecord] = []
+    for fs in file_stats:
+        filename = _local_name(fs.uri)
+        path = cache_dir / filename
+        if not path.exists():
+            continue
+        records.extend(_parse_file(path))
+    return records
+
+
+def read_synthetic_feature_records(n_records: int = 2000) -> List[FeatureRecord]:
+    """
+    Generate synthetic FeatureRecords for standalone / offline runs.
+
+    Mimics the distribution produced by the Flink CdcUserEventCountJob:
+    - 200 distinct users
+    - Event counts drawn from a log-normal distribution (realistic skew)
+    - 30-second tumbling windows
+    """
+    rng = random.Random(42)
+    now_ms = int(time.time() * 1000)
+    window_ms = 30_000
+    records: List[FeatureRecord] = []
+    for i in range(n_records):
+        user_id = rng.randint(1, 200)
+        event_count = max(1, int(rng.lognormvariate(2.0, 1.2)))
+        ws = now_ms - (i // 10) * window_ms
+        records.append(FeatureRecord(
+            user_id=user_id,
+            window_start_ms=ws,
+            window_end_ms=ws + window_ms,
+            event_count=event_count,
+        ))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Iceberg reader (optional — requires pyiceberg + catalog)
+# ---------------------------------------------------------------------------
+
+class IcebergFeatureReader:
+    """
+    Read features from an Iceberg table via pyiceberg.
+
+    Table schema mirrors the Flink IcebergSinkFactory output:
+      user_id LONG, window_start LONG, window_end LONG, event_count LONG
+
+    Falls back silently to the MinIO/synthetic path if pyiceberg is absent.
+    """
+
+    TABLE = os.environ.get("ICEBERG_TABLE", "streamforge.features.user_event_counts")
+    CATALOG_URI = os.environ.get("ICEBERG_CATALOG_URI", "")
+
+    def is_available(self) -> bool:
+        if not self.CATALOG_URI:
+            return False
+        try:
+            import pyiceberg  # type: ignore  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+    def read(self, limit: int = 5000) -> List[FeatureRecord]:
+        from pyiceberg.catalog import load_catalog  # type: ignore
+
+        catalog = load_catalog("default", **{"uri": self.CATALOG_URI})
+        table = catalog.load_table(self.TABLE)
+        scan = table.scan(limit=limit)
+        records = []
+        for batch in scan.to_arrow().to_pydict():
+            pass  # process via arrow batches
+        # Proper arrow read
+        arrow_table = table.scan(limit=limit).to_arrow()
+        col = arrow_table.column_names
+        for i in range(len(arrow_table)):
+            row = {c: arrow_table[c][i].as_py() for c in col}
+            records.append(FeatureRecord(
+                user_id=row.get("user_id", 0),
+                window_start_ms=row.get("window_start", 0),
+                window_end_ms=row.get("window_end", 0),
+                event_count=row.get("event_count", 0),
+            ))
+        return records
+
+
+# ---------------------------------------------------------------------------
+# MinIO object download into cache dir  (used by prefetch_warmer)
+# ---------------------------------------------------------------------------
+
+def download_to_cache(file_stats: List[FileStat], cache_dir: Path) -> int:
+    """
+    Download MinIO objects referenced in file_stats into cache_dir.
+
+    Returns the number of files successfully downloaded.
+    Used by prefetch_warmer as the real-MinIO path for prefetch_files().
+    """
+    client = _minio_client()
+    if client is None:
+        return 0
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    count = 0
+    for fs in file_stats:
+        if not fs.uri.startswith("minio://"):
+            continue
+        # Parse "minio://bucket/key"
+        rest = fs.uri[len("minio://"):]
+        bucket, _, key = rest.partition("/")
+        dest = cache_dir / _local_name(fs.uri)
+        try:
+            client.fget_object(bucket, key, str(dest))
+            count += 1
+        except Exception as exc:
+            print(f"[FEATURE_STORE] warn: failed to download {fs.uri}: {exc}")
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _local_name(uri: str) -> str:
+    """Map any URI to a safe flat filename."""
+    return uri.replace("minio://", "").replace("synthetic://", "").replace("/", "_")
+
+
+def _parse_file(path: Path) -> List[FeatureRecord]:
+    records: List[FeatureRecord] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return records
+
+    lines = [l.strip() for l in text.splitlines() if l.strip()]
+    for line in lines:
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        rec = _dict_to_record(obj)
+        if rec is not None:
+            records.append(rec)
+
+    # If single-object file, try parsing the whole text as one JSON
+    if not records:
+        try:
+            obj = json.loads(text)
+            if isinstance(obj, dict):
+                rec = _dict_to_record(obj)
+                if rec is not None:
+                    records.append(rec)
+        except json.JSONDecodeError:
+            pass
+
+    return records
+
+
+def _dict_to_record(obj: dict) -> Optional[FeatureRecord]:
+    try:
+        return FeatureRecord(
+            user_id=int(obj.get("user_id", obj.get("userId", 0))),
+            window_start_ms=int(obj.get("window_start", obj.get("window_start_ms", 0))),
+            window_end_ms=int(obj.get("window_end",   obj.get("window_end_ms",   0))),
+            event_count=int(obj.get("event_count", obj.get("eventCount", 0))),
+            sink_received_at=str(obj.get("sink_received_at", "")),
+        )
+    except (KeyError, ValueError, TypeError):
+        return None

--- a/examples/ml-training-prefetch/pipeline.py
+++ b/examples/ml-training-prefetch/pipeline.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+StreamForge AI — ML Training Pipeline with Prefetch Cache Warm-up
+
+End-to-end example that wires together the CDC → Flink → MinIO/Iceberg
+feature pipeline with the prefetch-engine and a sample ML training job.
+
+Pipeline stages
+---------------
+  1. [DISCOVER]  List feature files written by the Flink feature-sink to
+                 MinIO (bucket: processed, prefix: streamforge/features).
+                 Falls back to synthetic data when MinIO is unreachable.
+
+  2. [WARM]      Score and rank feature files by access frequency, then
+                 stage the hottest N files into a local cache directory
+                 using prefetch-engine/prefetch.py before training starts.
+
+  3. [READ]      Read FeatureRecord objects from the local cache (or
+                 from the Iceberg table when pyiceberg + catalog are
+                 configured via ICEBERG_CATALOG_URI).
+
+  4. [TRAIN]     Build a labelled dataset, train a user-activity classifier
+                 (scikit-learn RandomForest or pure-Python logistic
+                 regression), evaluate on a held-out test split.
+
+  5. [UPLOAD]    Persist the trained model artifact to MinIO at
+                 models/streamforge/ml/<job_id>/model.pkl.
+
+  6. [REPORT]    Print a structured timing and accuracy report.
+
+Usage
+-----
+  # Standalone — no external services needed:
+  python examples/ml-training-prefetch/pipeline.py
+
+  # Against the running demo stack (deploy/cdc-flink-minio-demo):
+  MINIO_ENDPOINT=localhost:9000 \\
+  MINIO_ACCESS_KEY=minioadmin   \\
+  MINIO_SECRET_KEY=minioadmin   \\
+  python examples/ml-training-prefetch/pipeline.py
+
+  # With Iceberg catalog:
+  ICEBERG_CATALOG_URI=http://localhost:8181 \\
+  python examples/ml-training-prefetch/pipeline.py
+
+  # Via Docker Compose (see docker-compose.yml in this directory):
+  docker compose up ml-trainer
+
+Environment variables
+---------------------
+  MINIO_ENDPOINT        MinIO host:port  (default: localhost:9000)
+  MINIO_ACCESS_KEY      (default: minioadmin)
+  MINIO_SECRET_KEY      (default: minioadmin)
+  MINIO_BUCKET          (default: processed)
+  MINIO_PREFIX          feature prefix   (default: streamforge/features)
+  MINIO_SECURE          (default: false)
+  ICEBERG_CATALOG_URI   REST catalog URL (optional; skipped if unset)
+  ICEBERG_TABLE         (default: streamforge.features.user_event_counts)
+  STREAMFORGE_JOB_ID    job identifier   (default: ml-<timestamp>)
+  STREAMFORGE_DEMO_DIR  base cache dir   (default: /tmp/streamforge-demo)
+  PREFETCH_TOP_N        hot files to warm (default: 50)
+  PREFETCH_LATENCY_S    simulated RTT     (default: 0.0)
+  N_SYNTHETIC_RECORDS   synthetic records when offline (default: 2000)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+# ── Add this directory to sys.path so sibling modules resolve cleanly ────────
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from feature_store import (
+    FeatureRecord,
+    IcebergFeatureReader,
+    list_minio_feature_files,
+    read_feature_records_from_cache,
+    read_synthetic_feature_records,
+)
+from prefetch_warmer import WarmupConfig, WarmupResult, warm_cache
+from trainer import TrainingResult, train
+
+
+# ---------------------------------------------------------------------------
+# Pipeline result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PipelineResult:
+    job_id: str
+    mode: str                      # "live-minio" | "live-iceberg" | "synthetic"
+    n_candidates: int
+    n_feature_records: int
+    warmup: WarmupResult
+    training: TrainingResult
+    total_duration_s: float
+
+    def print_report(self) -> None:
+        sep = "=" * 70
+        print(f"\n{sep}")
+        print("  StreamForge AI — ML Training Pipeline Report")
+        print(sep)
+        print(f"  Job ID          : {self.job_id}")
+        print(f"  Data mode       : {self.mode}")
+        print(f"  Feature files   : {self.n_candidates:,} discovered")
+        print(f"  Feature records : {self.n_feature_records:,} read")
+        print()
+        print("  ── Prefetch Warm-up ──────────────────────────────")
+        print(f"  Candidates      : {self.warmup.candidates_total:,}")
+        print(f"  Files warmed    : {self.warmup.files_warmed:,}")
+        print(f"  Cache hit-rate  : {self.warmup.hit_rate:.1%}")
+        print(f"  Prefetch time   : {self.warmup.prefetch_duration_s:.2f}s")
+        print()
+        print("  ── Model Training ────────────────────────────────")
+        print(f"  Backend         : {self.training.backend}")
+        print(f"  Train samples   : {self.training.n_train:,}")
+        print(f"  Test samples    : {self.training.n_test:,}")
+        print(f"  Accuracy        : {self.training.accuracy:.4f}")
+        print(f"  Train time      : {self.training.train_duration_s:.2f}s")
+        if self.training.minio_model_key:
+            print(f"  Model (MinIO)   : {self.training.minio_model_key}")
+        elif self.training.model_path:
+            print(f"  Model (local)   : {self.training.model_path}")
+        print()
+        print(f"  ── Total pipeline time: {self.total_duration_s:.2f}s ──")
+        warmup_pct = self.warmup.prefetch_duration_s / self.total_duration_s * 100
+        train_pct  = self.training.train_duration_s  / self.total_duration_s * 100
+        print(f"     Prefetch warm-up : {warmup_pct:.1f}%")
+        print(f"     Model training   : {train_pct:.1f}%")
+        print(sep + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Pipeline execution
+# ---------------------------------------------------------------------------
+
+def run_pipeline(
+    job_id: Optional[str] = None,
+    prefetch_top_n: int = 50,
+    prefetch_latency_s: float = 0.0,
+    n_synthetic: int = 2000,
+    cache_dir: Optional[Path] = None,
+) -> PipelineResult:
+
+    if job_id is None:
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        job_id = f"ml-{ts}"
+
+    t_pipeline_start = time.perf_counter()
+
+    # ── Stage 1: Discover feature files ─────────────────────────────────────
+    print(f"\n[PIPELINE] Job: {job_id}")
+    print("[PIPELINE] Stage 1/5 — discovering feature files …")
+
+    bucket = os.environ.get("MINIO_BUCKET",  "processed")
+    prefix = os.environ.get("MINIO_PREFIX",  "streamforge/features")
+
+    candidates, is_live_minio = list_minio_feature_files(
+        bucket=bucket, prefix=prefix, max_files=500
+    )
+    mode = "live-minio" if is_live_minio else "synthetic"
+    print(f"[PIPELINE]   mode={mode}  candidates={len(candidates):,}")
+
+    # ── Stage 2: Prefetch warm-up ────────────────────────────────────────────
+    print("[PIPELINE] Stage 2/5 — warming prefetch cache …")
+    warmup_cfg = WarmupConfig(
+        top_n=prefetch_top_n,
+        simulate_latency_s=prefetch_latency_s,
+        use_real_download=is_live_minio,
+        cache_dir=cache_dir,
+        job_id=job_id,
+    )
+    warmup_result = warm_cache(candidates, warmup_cfg)
+    warmup_result.print_summary()
+
+    # ── Stage 3: Read feature records ────────────────────────────────────────
+    print("[PIPELINE] Stage 3/5 — reading feature records from cache …")
+
+    # Try Iceberg first (highest fidelity)
+    iceberg = IcebergFeatureReader()
+    if iceberg.is_available():
+        print("[PIPELINE]   reading from Iceberg catalog …")
+        records: List[FeatureRecord] = iceberg.read()
+        mode = "live-iceberg"
+    elif is_live_minio and warmup_result.files_warmed > 0:
+        records = read_feature_records_from_cache(
+            warmup_result.cache_dir, warmup_result.hot_files
+        )
+        print(f"[PIPELINE]   read {len(records):,} records from MinIO cache")
+    else:
+        records = read_synthetic_feature_records(n_records=n_synthetic)
+        print(f"[PIPELINE]   generated {len(records):,} synthetic records")
+
+    if not records:
+        # Cache files present but empty — generate synthetics as fallback
+        print("[PIPELINE]   warn: no records in cache; using synthetic data")
+        records = read_synthetic_feature_records(n_records=n_synthetic)
+
+    # ── Stage 4: Train ───────────────────────────────────────────────────────
+    print(f"[PIPELINE] Stage 4/5 — training on {len(records):,} feature records …")
+    training_result = train(records, job_id=job_id)
+
+    # ── Stage 5: Report ──────────────────────────────────────────────────────
+    total_s = time.perf_counter() - t_pipeline_start
+    print("[PIPELINE] Stage 5/5 — building report …")
+
+    result = PipelineResult(
+        job_id=job_id,
+        mode=mode,
+        n_candidates=len(candidates),
+        n_feature_records=len(records),
+        warmup=warmup_result,
+        training=training_result,
+        total_duration_s=total_s,
+    )
+    result.print_report()
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="StreamForge AI ML training pipeline with prefetch cache warm-up"
+    )
+    p.add_argument("--job-id",     default=None,
+                   help="Job identifier (default: ml-<timestamp>)")
+    p.add_argument("--top-n",      type=int,   default=int(os.environ.get("PREFETCH_TOP_N", 50)),
+                   help="Number of hot files to prefetch (default: 50)")
+    p.add_argument("--latency",    type=float, default=float(os.environ.get("PREFETCH_LATENCY_S", 0.0)),
+                   help="Simulated per-file prefetch latency in seconds (default: 0.0)")
+    p.add_argument("--synthetic",  type=int,   default=int(os.environ.get("N_SYNTHETIC_RECORDS", 2000)),
+                   help="Synthetic records to generate when offline (default: 2000)")
+    p.add_argument("--cache-dir",  default=None,
+                   help="Override local cache directory path")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    cache_dir = Path(args.cache_dir) if args.cache_dir else None
+    run_pipeline(
+        job_id=args.job_id,
+        prefetch_top_n=args.top_n,
+        prefetch_latency_s=args.latency,
+        n_synthetic=args.synthetic,
+        cache_dir=cache_dir,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/ml-training-prefetch/prefetch_warmer.py
+++ b/examples/ml-training-prefetch/prefetch_warmer.py
@@ -1,0 +1,246 @@
+"""
+Prefetch Warmer — bridge between prefetch-engine/ and the ML training pipeline.
+
+This module is the seam that connects two previously separate concerns:
+
+  prefetch-engine/prefetch.py   ← hot-file selection + local caching logic
+  feature_store.py              ← MinIO discovery + feature reading
+
+Flow
+----
+  1. Receive a FileStat manifest from feature_store.list_minio_feature_files()
+  2. Score and rank files with select_hot_files()
+  3. Stage hot files into a local cache with prefetch_files()  (real MinIO or
+     synthetic file copy depending on the URI scheme)
+  4. Return WarmupResult with timing and hit-rate statistics
+
+The caller (pipeline.py) waits for warm_cache() to complete before starting
+the trainer, guaranteeing that training reads only from the local cache.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+# ── Locate prefetch-engine on sys.path ──────────────────────────────────────
+_HERE = Path(__file__).resolve().parent
+_REPO_ROOT = _HERE.parent.parent
+_PE_PATH = str(_REPO_ROOT / "prefetch-engine")
+if _PE_PATH not in sys.path:
+    sys.path.insert(0, _PE_PATH)
+
+from prefetch import select_hot_files  # type: ignore
+import metrics as _pe_metrics           # type: ignore
+
+# Re-export FileStat from feature_store so callers import from one place
+from feature_store import FileStat, download_to_cache  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WarmupConfig:
+    """Tunable knobs for the prefetch warm phase."""
+
+    top_n: int = 50
+    """How many hot files to stage in the local cache."""
+
+    cache_dir: Optional[Path] = None
+    """
+    Where to write the local cache.  Defaults to a temp directory created
+    inside STREAMFORGE_DEMO_DIR (or /tmp/streamforge-demo).
+    """
+
+    simulate_latency_s: float = 0.0
+    """
+    Per-file simulated remote-read latency (seconds).
+    Set > 0 to reproduce MinIO RTT in local / CI runs.
+    Use 0.0 (default) when a real MinIO is present — actual I/O provides
+    the latency.
+    """
+
+    use_real_download: bool = True
+    """
+    True  → download real MinIO objects via feature_store.download_to_cache()
+    False → copy synthetic/local files with shutil (for CI / offline runs)
+    """
+
+    job_id: str = "ml-training"
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+@dataclass
+class WarmupResult:
+    hot_files: List[FileStat]
+    cache_dir: Path
+    candidates_total: int
+    files_warmed: int
+    files_skipped: int
+    prefetch_duration_s: float
+    hit_rate: float          # fraction of hot_files actually in cache after warm
+
+    def print_summary(self) -> None:
+        print(f"[WARMER] candidates={self.candidates_total:,}  "
+              f"selected={len(self.hot_files)}  "
+              f"warmed={self.files_warmed}  "
+              f"skipped={self.files_skipped}")
+        print(f"[WARMER] prefetch took {self.prefetch_duration_s:.2f}s  "
+              f"cache hit-rate after warm: {self.hit_rate:.1%}")
+        print(f"[WARMER] cache dir: {self.cache_dir}")
+
+
+# ---------------------------------------------------------------------------
+# Core warm_cache()
+# ---------------------------------------------------------------------------
+
+def warm_cache(
+    candidates: List[FileStat],
+    config: WarmupConfig,
+) -> WarmupResult:
+    """
+    Select the hottest files from ``candidates`` and stage them into a local
+    cache directory before training starts.
+
+    This is the primary integration point: calling this function guarantees
+    that the training job will find its highest-priority feature files on
+    local storage, not in remote MinIO.
+    """
+    cache_dir = _resolve_cache_dir(config.cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    # ── Phase 1: rank by access score ───────────────────────────────────────
+    hot_files = select_hot_files(candidates, top_n=config.top_n)
+    print(f"[WARMER] selected {len(hot_files)}/{len(candidates)} hot files for prefetch")
+
+    # ── Phase 2: stage into cache ────────────────────────────────────────────
+    t0 = time.perf_counter()
+    warmed, skipped = _stage_files(hot_files, cache_dir, config)
+    duration_s = time.perf_counter() - t0
+
+    # ── Phase 3: measure actual hit-rate ────────────────────────────────────
+    hits = sum(1 for f in hot_files if (cache_dir / _filename(f.uri)).exists())
+    hit_rate = hits / len(hot_files) if hot_files else 0.0
+
+    # Emit prefetch-engine Prometheus metrics (best-effort)
+    try:
+        _pe_metrics.prefetch_duration_seconds.labels(
+            job_id=config.job_id
+        ).observe(duration_s)
+        _pe_metrics.files_prefetched_total.labels(
+            job_id=config.job_id
+        ).inc(warmed)
+        _pe_metrics.cache_hits_total.labels(
+            job_id=config.job_id
+        ).inc(hits)
+    except Exception:
+        pass
+
+    return WarmupResult(
+        hot_files=hot_files,
+        cache_dir=cache_dir,
+        candidates_total=len(candidates),
+        files_warmed=warmed,
+        files_skipped=skipped,
+        prefetch_duration_s=duration_s,
+        hit_rate=hit_rate,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Staging strategies
+# ---------------------------------------------------------------------------
+
+def _stage_files(
+    hot_files: List[FileStat],
+    cache_dir: Path,
+    config: WarmupConfig,
+) -> Tuple[int, int]:
+    """
+    Copy hot files into cache_dir using whichever strategy fits the URI scheme.
+    Returns (warmed_count, skipped_count).
+    """
+    minio_files = [f for f in hot_files if f.uri.startswith("minio://")]
+    local_files  = [f for f in hot_files if not f.uri.startswith("minio://")]
+
+    warmed = 0
+    skipped = 0
+
+    # Real MinIO objects
+    if minio_files and config.use_real_download:
+        downloaded = download_to_cache(minio_files, cache_dir)
+        warmed += downloaded
+        skipped += len(minio_files) - downloaded
+
+    # Synthetic / local files — write placeholder content representing the
+    # feature batch so trainer.py can read them from cache_dir
+    for fs in local_files:
+        dest = cache_dir / _filename(fs.uri)
+        if dest.exists():
+            warmed += 1
+            continue
+        if config.simulate_latency_s > 0:
+            time.sleep(config.simulate_latency_s)
+        try:
+            _write_synthetic_feature_file(dest, fs)
+            warmed += 1
+        except OSError:
+            skipped += 1
+
+    return warmed, skipped
+
+
+def _write_synthetic_feature_file(dest: Path, fs: FileStat) -> None:
+    """
+    Write a realistic synthetic feature NDJSON file.
+
+    Simulates what the Flink feature-sink would write to MinIO so that
+    trainer.py can parse it identically in online and offline modes.
+    """
+    import json
+    import random
+    rng = random.Random(hash(fs.uri) % (2**32))
+    lines = []
+    for _ in range(rng.randint(10, 50)):
+        user_id = rng.randint(1, 200)
+        event_count = max(1, int(rng.lognormvariate(2.0, 1.2)))
+        ws = int(fs.last_access_epoch * 1000)
+        lines.append(json.dumps({
+            "user_id": user_id,
+            "window_start": ws,
+            "window_end": ws + 30_000,
+            "event_count": event_count,
+            "sink_received_at": "synthetic",
+        }))
+    dest.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_cache_dir(cfg_dir: Optional[Path]) -> Path:
+    if cfg_dir is not None:
+        return cfg_dir
+    base = Path(os.environ.get("STREAMFORGE_DEMO_DIR", "/tmp/streamforge-demo"))
+    return base / "prefetch-cache" / "ml-training"
+
+
+def _filename(uri: str) -> str:
+    """Flatten any URI into a safe local filename."""
+    return (uri
+            .replace("minio://", "")
+            .replace("synthetic://", "")
+            .replace("file://", "")
+            .replace("/", "_"))

--- a/examples/ml-training-prefetch/requirements.txt
+++ b/examples/ml-training-prefetch/requirements.txt
@@ -1,0 +1,18 @@
+# ML Training + Prefetch Example — Python dependencies
+#
+# Core (inherited from prefetch-engine/requirements.txt):
+#   minio>=7.2.7
+#   prometheus_client>=0.20
+#
+# Optional ML backends — the pipeline works without either:
+#   scikit-learn  — enables RandomForestClassifier (more realistic training)
+#   pyiceberg     — enables direct Iceberg table reads (requires catalog URI)
+#
+# Install all optional deps:
+#   pip install -r examples/ml-training-prefetch/requirements.txt
+
+# Optional ML backend
+scikit-learn>=1.4.0
+
+# Optional Iceberg reader
+# pyiceberg>=0.6.0

--- a/examples/ml-training-prefetch/trainer.py
+++ b/examples/ml-training-prefetch/trainer.py
@@ -1,0 +1,304 @@
+"""
+ML Trainer — trains a user-activity classifier on prefetched feature records.
+
+Task
+----
+Predict whether a user is "high-activity" in a given 30-second window based
+on their event_count.  Labels:
+  0 = low    (event_count ≤ 33rd percentile)
+  1 = medium (33rd < event_count ≤ 66th percentile)
+  2 = high   (event_count > 66th percentile)
+
+Model
+-----
+Logistic Regression (one-vs-rest) implemented in pure Python + optional numpy.
+When scikit-learn is installed a RandomForestClassifier is used instead for
+a more realistic training workload.  Both paths consume identical FeatureRecord
+inputs and produce identical TrainingResult outputs.
+
+Model persistence
+-----------------
+The trained model is serialised with pickle and optionally uploaded to MinIO
+at: models/streamforge/ml/<job_id>/model.pkl
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import pickle
+import random
+import time
+from dataclasses import dataclass, field
+from io import BytesIO
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+from feature_store import FeatureRecord
+
+
+# ---------------------------------------------------------------------------
+# Dataset preparation
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TrainingDataset:
+    features: List[List[float]]   # [[event_count, event_rate, user_id_norm], ...]
+    labels: List[int]             # 0 / 1 / 2
+    user_ids: List[int]
+    n_classes: int = 3
+
+    @property
+    def n_samples(self) -> int:
+        return len(self.labels)
+
+    @property
+    def class_counts(self) -> Dict[int, int]:
+        counts: Dict[int, int] = {0: 0, 1: 0, 2: 0}
+        for lbl in self.labels:
+            counts[lbl] = counts.get(lbl, 0) + 1
+        return counts
+
+
+def build_dataset(records: List[FeatureRecord]) -> TrainingDataset:
+    """
+    Convert FeatureRecords to a labelled feature matrix.
+
+    Features per sample:
+      x0 = log1p(event_count)           — main signal
+      x1 = event_rate (events / window_s) — derived
+      x2 = user_id / 200.0              — normalised user identity
+
+    Labels are determined by the 33rd and 66th percentile of event_count
+    across the dataset so they balance across any distribution.
+    """
+    if not records:
+        raise ValueError("Cannot build a dataset from zero feature records.")
+
+    counts = sorted(r.event_count for r in records)
+    n = len(counts)
+    p33 = counts[n // 3]
+    p66 = counts[(2 * n) // 3]
+
+    def label(ec: int) -> int:
+        if ec <= p33:
+            return 0
+        if ec <= p66:
+            return 1
+        return 2
+
+    features, labels, user_ids = [], [], []
+    for r in records:
+        features.append([
+            math.log1p(r.event_count),
+            r.event_rate,
+            r.user_id / 200.0,
+        ])
+        labels.append(label(r.event_count))
+        user_ids.append(r.user_id)
+
+    return TrainingDataset(features=features, labels=labels, user_ids=user_ids)
+
+
+def train_test_split(
+    dataset: TrainingDataset,
+    test_ratio: float = 0.2,
+    seed: int = 42,
+) -> Tuple[TrainingDataset, TrainingDataset]:
+    rng = random.Random(seed)
+    indices = list(range(dataset.n_samples))
+    rng.shuffle(indices)
+    split = int(len(indices) * (1 - test_ratio))
+    train_idx, test_idx = indices[:split], indices[split:]
+
+    def subset(idx: List[int]) -> TrainingDataset:
+        return TrainingDataset(
+            features=[dataset.features[i] for i in idx],
+            labels=[dataset.labels[i] for i in idx],
+            user_ids=[dataset.user_ids[i] for i in idx],
+        )
+
+    return subset(train_idx), subset(test_idx)
+
+
+# ---------------------------------------------------------------------------
+# Pure-Python logistic regression (stdlib-only fallback)
+# ---------------------------------------------------------------------------
+
+class _PurePythonLR:
+    """
+    Mini one-vs-rest logistic regression using gradient descent.
+    No numpy required — uses only Python lists and math.
+    """
+
+    def __init__(self, n_classes: int = 3, lr: float = 0.05,
+                 epochs: int = 40, seed: int = 42):
+        self.n_classes = n_classes
+        self.lr = lr
+        self.epochs = epochs
+        self._rng = random.Random(seed)
+        self.weights: List[List[float]] = []
+        self.biases: List[float] = []
+
+    def _sigmoid(self, z: float) -> float:
+        return 1.0 / (1.0 + math.exp(-max(-500.0, min(500.0, z))))
+
+    def _dot(self, w: List[float], x: List[float]) -> float:
+        return sum(wi * xi for wi, xi in zip(w, x))
+
+    def fit(self, X: List[List[float]], y: List[int]) -> None:
+        n_features = len(X[0])
+        self.weights = [
+            [self._rng.gauss(0, 0.01) for _ in range(n_features)]
+            for _ in range(self.n_classes)
+        ]
+        self.biases = [0.0] * self.n_classes
+
+        for _ in range(self.epochs):
+            for xi, yi in zip(X, y):
+                for c in range(self.n_classes):
+                    target = 1.0 if yi == c else 0.0
+                    pred = self._sigmoid(self._dot(self.weights[c], xi) + self.biases[c])
+                    err = pred - target
+                    self.biases[c] -= self.lr * err
+                    for j in range(n_features):
+                        self.weights[c][j] -= self.lr * err * xi[j]
+
+    def predict(self, X: List[List[float]]) -> List[int]:
+        preds = []
+        for xi in X:
+            scores = [
+                self._sigmoid(self._dot(self.weights[c], xi) + self.biases[c])
+                for c in range(self.n_classes)
+            ]
+            preds.append(scores.index(max(scores)))
+        return preds
+
+    def score(self, X: List[List[float]], y: List[int]) -> float:
+        preds = self.predict(X)
+        return sum(p == t for p, t in zip(preds, y)) / len(y)
+
+
+# ---------------------------------------------------------------------------
+# scikit-learn wrapper (used when available)
+# ---------------------------------------------------------------------------
+
+def _sklearn_model():
+    try:
+        from sklearn.ensemble import RandomForestClassifier  # type: ignore
+        return RandomForestClassifier(n_estimators=50, max_depth=6, random_state=42)
+    except ImportError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Training result
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TrainingResult:
+    job_id: str
+    n_train: int
+    n_test: int
+    accuracy: float
+    train_duration_s: float
+    backend: str          # "sklearn" | "pure-python"
+    model_path: Optional[str] = None     # local path to saved model
+    minio_model_key: Optional[str] = None  # MinIO object key if uploaded
+
+
+# ---------------------------------------------------------------------------
+# Main trainer entry point
+# ---------------------------------------------------------------------------
+
+def train(
+    records: List[FeatureRecord],
+    job_id: str = "ml-training",
+    model_dir: Optional[Path] = None,
+) -> TrainingResult:
+    """
+    Build a dataset from feature records, train a classifier, evaluate it,
+    and persist the model artifact.
+    """
+    print(f"[TRAINER] Building dataset from {len(records):,} feature records …")
+    dataset = build_dataset(records)
+    train_ds, test_ds = train_test_split(dataset)
+    print(f"[TRAINER] train={train_ds.n_samples:,}  test={test_ds.n_samples:,}  "
+          f"classes={dataset.class_counts}")
+
+    sklearn_model = _sklearn_model()
+    backend = "sklearn" if sklearn_model is not None else "pure-python"
+    print(f"[TRAINER] Using backend: {backend}")
+
+    t0 = time.perf_counter()
+    if sklearn_model is not None:
+        sklearn_model.fit(train_ds.features, train_ds.labels)
+        accuracy = float(sklearn_model.score(test_ds.features, test_ds.labels))
+        model_obj = sklearn_model
+    else:
+        lr = _PurePythonLR(n_classes=dataset.n_classes)
+        lr.fit(train_ds.features, train_ds.labels)
+        accuracy = lr.score(test_ds.features, test_ds.labels)
+        model_obj = lr
+    train_duration_s = time.perf_counter() - t0
+
+    print(f"[TRAINER] Accuracy={accuracy:.4f}  train_time={train_duration_s:.2f}s")
+
+    # Persist model
+    model_path = _save_model(model_obj, job_id, model_dir)
+    minio_key = _upload_model(model_path, job_id)
+
+    return TrainingResult(
+        job_id=job_id,
+        n_train=train_ds.n_samples,
+        n_test=test_ds.n_samples,
+        accuracy=accuracy,
+        train_duration_s=train_duration_s,
+        backend=backend,
+        model_path=str(model_path),
+        minio_model_key=minio_key,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Model persistence helpers
+# ---------------------------------------------------------------------------
+
+def _save_model(model_obj: object, job_id: str, model_dir: Optional[Path]) -> Path:
+    if model_dir is None:
+        base = Path(os.environ.get("STREAMFORGE_DEMO_DIR", "/tmp/streamforge-demo"))
+        model_dir = base / "models"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    path = model_dir / f"{job_id}_model.pkl"
+    path.write_bytes(pickle.dumps(model_obj))
+    print(f"[TRAINER] Model saved to {path}")
+    return path
+
+
+def _upload_model(model_path: Path, job_id: str) -> Optional[str]:
+    endpoint   = os.environ.get("MINIO_ENDPOINT",   "")
+    access_key = os.environ.get("MINIO_ACCESS_KEY", "minioadmin")
+    secret_key = os.environ.get("MINIO_SECRET_KEY", "minioadmin")
+    bucket     = os.environ.get("MINIO_BUCKET",     "processed")
+    secure     = os.environ.get("MINIO_SECURE",     "false").lower() == "true"
+
+    if not endpoint:
+        print("[TRAINER] MinIO not configured — model upload skipped.")
+        return None
+
+    try:
+        from minio import Minio  # type: ignore
+        client = Minio(endpoint, access_key=access_key,
+                       secret_key=secret_key, secure=secure)
+        if not client.bucket_exists(bucket):
+            client.make_bucket(bucket)
+        key = f"streamforge/models/{job_id}/model.pkl"
+        data = model_path.read_bytes()
+        client.put_object(bucket, key, BytesIO(data), len(data),
+                          content_type="application/octet-stream")
+        print(f"[TRAINER] Model uploaded → minio://{bucket}/{key}")
+        return key
+    except Exception as exc:
+        print(f"[TRAINER] Model upload failed (non-fatal): {exc}")
+        return None


### PR DESCRIPTION
…rm-up

Adds examples/ml-training-prefetch/ — a fully wired example that connects the CDC → Flink → MinIO/Iceberg feature pipeline to a sample ML training job, using prefetch-engine/ to warm the local cache before training starts.

Pipeline stages
---------------
1. DISCOVER  list_minio_feature_files() scans MinIO bucket for feature files written by the Flink feature-sink; falls back to synthetic data when no broker is reachable (zero external dependencies needed).

2. WARM      prefetch_warmer.warm_cache() calls select_hot_files() + the
             prefetch staging logic from prefetch-engine/prefetch.py to stage
             the top-N hottest feature files into a local cache directory
             before training starts — guaranteeing reads from local storage.

3. READ      feature_store.read_feature_records_from_cache() reads NDJSON
             records from the cache; IcebergFeatureReader used instead when
             pyiceberg + ICEBERG_CATALOG_URI are configured.

4. TRAIN     trainer.train() builds a labelled dataset (low/medium/high
             activity labels from event_count percentiles), trains a
             RandomForestClassifier (scikit-learn) or falls back to a
             pure-Python logistic regression (stdlib only), and evaluates
             accuracy on a held-out test split.

5. UPLOAD    trained model artifact uploaded to MinIO at
             processed/streamforge/models/<job_id>/model.pkl.

New files
---------
  examples/ml-training-prefetch/pipeline.py       — orchestrator entry point
  examples/ml-training-prefetch/feature_store.py  — MinIO/Iceberg discovery + read
  examples/ml-training-prefetch/prefetch_warmer.py — prefetch-engine bridge
  examples/ml-training-prefetch/trainer.py         — ML dataset + model training
  examples/ml-training-prefetch/Dockerfile         — image (build ctx = repo root)
  examples/ml-training-prefetch/docker-compose.yml — ml-trainer service + standalone profile
  examples/ml-training-prefetch/requirements.txt   — optional scikit-learn / pyiceberg
  examples/ml-training-prefetch/README.md          — usage, env vars, data-flow diagram