### PR TITLE
feat(schema-evolution): end-to-end Debezium schema change handling

### DIFF
--- a/docs/SCHEMA_EVOLUTION.md
+++ b/docs/SCHEMA_EVOLUTION.md
@@ -1,0 +1,209 @@
+# Schema Evolution Policy — Debezium → Kafka → Flink → Sink
+
+This document defines the compatibility policy for schema changes that flow through
+the StreamForge CDC pipeline, explains how each change type is handled end-to-end,
+and provides a step-by-step reprocessing runbook for incompatible changes.
+
+---
+
+## 1. Compatibility Policy
+
+### 1.1 Change taxonomy
+
+| Change type | Example DDL | Default compatibility | Flink job action |
+|---|---|---|---|
+| **ADD COLUMN (nullable)** | `ALTER TABLE t ADD COLUMN session_id VARCHAR(64)` | **FULL** | Null-fill for pre-DDL events; pass through |
+| **DROP COLUMN (optional)** | `ALTER TABLE t DROP COLUMN ip_address` | **FORWARD** | Null-fill; pass through |
+| **DROP COLUMN (required)** | `ALTER TABLE t DROP COLUMN user_id` | **BREAKING** | Route to DLQ |
+| **RENAME COLUMN (registered alias)** | + `COLUMN_ALIASES=new_name=old_name` | **BACKWARD** | Alias resolves; pass through |
+| **RENAME COLUMN (no alias)** | No alias registered | **BREAKING** | Route to DLQ |
+| **TYPE WIDENING** | `ALTER TABLE t MODIFY created_at BIGINT` | **BACKWARD** | Annotate event; pass through |
+| **TYPE NARROWING** | `ALTER TABLE t MODIFY amount INT` | **BREAKING** | Route to DLQ |
+| **INCOMPATIBLE TYPE** | `ALTER TABLE t MODIFY ts VARCHAR(32)` | **BREAKING** | Route to DLQ |
+
+### 1.2 Compatibility definitions
+
+- **FULL** — new schema reads old data AND old schema reads new data.  Zero action required.
+- **BACKWARD** — new schema reads old data.  Flink job can continue with the current binary.
+- **FORWARD** — old schema reads new data.  Unknown fields are silently ignored by `@JsonIgnoreProperties`.
+- **BREAKING** — neither direction is safe.  Events land in the dead-letter queue until the issue is remediated.
+
+### 1.3 Required columns
+
+`user_id` is currently the only **required** column.  If it is absent after all alias
+normalization, the event is unconditionally routed to the DLQ regardless of op type.
+
+---
+
+## 2. How each change is handled in code
+
+### 2.1 Column add
+
+`SchemaEvolutionHandler.normalizeRow()` null-fills fields absent in the JSON.
+`CdcEvent.UserEventRow` has `@JsonIgnoreProperties(ignoreUnknown = true)` so new columns
+in future schema versions do not cause parsing failures.
+
+**New columns introduced so far:**
+
+| Column | Version | Handling |
+|---|---|---|
+| `session_id` | V2 | null-filled in V1 events |
+| `ip_address` | V2 | null-filled in V1 events |
+| `metadata` | V3 | null-filled in V1/V2 events |
+
+### 2.2 Column drop
+
+`resolveText()` and `resolveTimestamp()` return `null` when neither the canonical name nor
+any registered alias is present.  If the missing column is `user_id`, a
+`SchemaChange(DROP_COLUMN)` is added to `CdcEvent.detectedChanges` and `SchemaEvolutionFilter`
+routes the event to the DLQ.
+
+### 2.3 Column rename
+
+**With a registered alias** (BACKWARD compatible):
+
+```
+# At job start, or via savepoint + redeploy:
+COLUMN_ALIASES=customer_id=user_id,kind=event_type
+```
+
+`ColumnAliasRegistry` resolves `customer_id` → `user_id` transparently.  The main job
+continues processing without interruption.
+
+**Without a registered alias** (BREAKING):
+
+`user_id` is absent → `DROP_COLUMN` change detected → event routed to DLQ.
+Follow the **Reprocessing Runbook** in §4.
+
+### 2.4 Type widening (BACKWARD compatible)
+
+`TypeCompatibilityChecker.check()` compares the JSON node value against the expected type.
+When `created_at` overflows a 32-bit int, a `SchemaChange(WIDEN_TYPE)` is appended to
+`detectedChanges`.  The event passes through normally — the value is read as a `long`.
+The schema version is promoted to `V3` when this overflow is detected.
+
+### 2.5 Incompatible type change (BREAKING)
+
+When `TypeCompatibilityChecker` detects a `INCOMPATIBLE_TYPE` or `NARROW_TYPE` change,
+`SchemaEvolutionFilter` routes the event to the DLQ with the affected column and old/new
+type hints.
+
+---
+
+## 3. Dead-letter queue (DLQ) structure
+
+Topic: `cdc.dead.letter` (configurable via `KAFKA_DLQ_TOPIC`)
+
+Each `DeadLetterEvent` carries:
+
+| Field | Purpose |
+|---|---|
+| `rawPayload` | Original Debezium JSON for replay |
+| `errorMessage` | Human-readable description |
+| `changeType` | `DROP_COLUMN`, `RENAME_COLUMN`, `INCOMPATIBLE_TYPE`, `NARROW_TYPE` |
+| `schemaVersion` | Version detected before rejection (`V1`, `V2`, `V3`, `UNKNOWN`) |
+| `affectedColumn` | Column that triggered the rejection |
+| `compatibilityLevel` | Always `BREAKING` for DLQ entries |
+| `failedAtMs` | Epoch-ms of rejection |
+
+---
+
+## 4. Reprocessing Runbook
+
+### Case A: Column rename (most common)
+
+**Symptoms:** DLQ spike; `changeType=DROP_COLUMN`, `affectedColumn=user_id` (or other required column).
+
+**Remediation:**
+
+```bash
+# 1. Identify the new column name from the Debezium schema history topic
+#    (or from the DBA who ran the ALTER TABLE).
+NEW_COLUMN=customer_id
+
+# 2. Take a savepoint of the running Flink job.
+flink savepoint <job-id> s3://your-bucket/savepoints/
+
+# 3. Redeploy the main job with the alias env var set.
+#    The alias registry is loaded at open() time — no recompile needed.
+COLUMN_ALIASES="${NEW_COLUMN}=user_id" \
+  flink run -s <savepoint-path> target/stream-processor-*.jar
+
+# 4. Submit the DlqReprocessingJob (one-shot) to replay DLQ events
+#    through the updated alias registry back into the main source topic.
+COLUMN_ALIASES="${NEW_COLUMN}=user_id" \
+KAFKA_DLQ_TOPIC=cdc.dead.letter \
+KAFKA_SOURCE_TOPIC=cdc.streamforge.user_events \
+  flink run target/stream-processor-*.jar \
+  --class ai.streamforge.processor.reprocessing.DlqReprocessingJob
+
+# 5. Monitor cdc.dead.letter.unresolved — events here could not be recovered.
+#    Manual review required for those.
+```
+
+### Case B: Type widening (INT → BIGINT)
+
+No action required.  `WIDEN_TYPE` is BACKWARD compatible.
+The `detectedChanges` list on the event is available for observability
+(emit it to a metrics topic or log it at DEBUG level if needed).
+
+### Case C: Incompatible type change (e.g., timestamp column changed to VARCHAR)
+
+**Symptoms:** DLQ spike; `changeType=INCOMPATIBLE_TYPE`.
+
+This is a source-schema bug.  Reprocessing is only meaningful after the source
+is corrected or a coercion transform is introduced upstream.
+
+```bash
+# Option 1: Fix the source schema and resume from the pre-DDL savepoint.
+flink run -s <pre-ddl-savepoint> target/stream-processor-*.jar
+
+# Option 2: Full replay — reset consumer group offset and rerun from earliest.
+#   This reprocesses all history; use only if the window of bad events is small.
+kafka-consumer-groups --bootstrap-server kafka:9092 \
+  --group flink-cdc-user-event-count --reset-offsets \
+  --topic cdc.streamforge.user_events --to-earliest --execute
+
+flink run target/stream-processor-*.jar
+```
+
+### Case D: Required column dropped permanently
+
+The source schema must be updated (column restored or renamed).
+If the column is permanently removed, update `SchemaEvolutionHandler.normalizeRow()`
+to not require it, then redeploy and replay via `DlqReprocessingJob`.
+
+---
+
+## 5. Adding a new required column
+
+1. Add the field to `CdcEvent.UserEventRow` with `@JsonProperty`.
+2. Add resolution logic to `SchemaEvolutionHandler.normalizeRow()`.
+3. Add a null-check in `SchemaEvolutionFilter.classify()` (analogous to the `user_id` check).
+4. Bump `SchemaVersion` if needed.
+5. Update the compatibility table in §1.1.
+
+---
+
+## 6. Adding a new alias at deploy time
+
+Add to the `COLUMN_ALIASES` environment variable (no recompile needed):
+
+```
+COLUMN_ALIASES=old_col=canonical,another_old=another_canonical
+```
+
+The alias registry is built at `DeserializationSchema.open()` time from this env var
+plus the built-in aliases.  A savepoint-restore cycle picks up the new aliases without
+losing Flink state.
+
+---
+
+## 7. Schema version summary
+
+| Version | Fields | Detected when |
+|---|---|---|
+| V1 | `user_id`, `event_type`, `created_at` | Core fields present, no V2/V3 fields |
+| V2 | + `session_id`, `ip_address` | `session_id` or `ip_address` present |
+| V3 | + `metadata` blob, or `created_at` > INT_MAX | `metadata` present, or timestamp overflows int |
+| UNKNOWN | No recognizable key field | `after` is null, or no known field found |

--- a/stream-processor/src/main/java/ai/streamforge/processor/deserialization/SchemaEvolutionFilter.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/deserialization/SchemaEvolutionFilter.java
@@ -2,21 +2,35 @@ package ai.streamforge.processor.deserialization;
 
 import ai.streamforge.processor.model.CdcEvent;
 import ai.streamforge.processor.model.DeadLetterEvent;
+import ai.streamforge.processor.schema.ChangeType;
+import ai.streamforge.processor.schema.CompatibilityLevel;
+import ai.streamforge.processor.schema.SchemaChange;
 import org.apache.flink.streaming.api.functions.ProcessFunction;
 import org.apache.flink.util.Collector;
 import org.apache.flink.util.OutputTag;
 
+import java.util.List;
+
 /**
  * Routes {@link CdcEvent} records between the main stream and the dead-letter
- * side output.
+ * side output based on schema evolution compatibility.
  *
- * <p>A record is sent to the dead-letter queue when it is an insert ({@code op=c})
- * or snapshot read ({@code op=r}) whose {@code after.userId} could not be resolved
- * after schema normalization.  This covers the case where the column was renamed to
- * an unrecognised alias or removed entirely.  All other events (updates, deletes,
- * and valid inserts) pass through to the main output unchanged.
+ * <h3>Routing rules (applied in order)</h3>
+ * <ol>
+ *   <li><b>Null event</b> — silently dropped (parse failure logged by the deserializer).</li>
+ *   <li><b>BREAKING schema change detected</b> — any event whose {@code detectedChanges}
+ *       list contains a change with {@link CompatibilityLevel#BREAKING} compatibility is
+ *       sent to the DLQ.  The {@link DeadLetterEvent} carries the {@link ChangeType},
+ *       affected column, and schema version to guide remediation.</li>
+ *   <li><b>Insert/snapshot with missing required field</b> — an insert ({@code op=c}) or
+ *       snapshot read ({@code op=r}) whose {@code after.userId} could not be resolved is
+ *       sent to the DLQ.</li>
+ *   <li><b>Non-breaking changes</b> — BACKWARD/FULL changes (type widenings, new nullable
+ *       columns) pass through with the {@code detectedChanges} list intact for observability.</li>
+ *   <li><b>Everything else</b> — passes through unchanged.</li>
+ * </ol>
  *
- * <p>Wire in the job:
+ * <h3>Wire-up example</h3>
  * <pre>{@code
  * SingleOutputStreamOperator<CdcEvent> filtered =
  *         rawEvents.process(new SchemaEvolutionFilter()).name("Schema Evolution Filter");
@@ -29,18 +43,68 @@ public class SchemaEvolutionFilter extends ProcessFunction<CdcEvent, CdcEvent> {
             new OutputTag<DeadLetterEvent>("dead-letter") {};
 
     @Override
-    public void processElement(
-            CdcEvent event,
-            Context ctx,
-            Collector<CdcEvent> out) {
-
-        if (isInsertOrRead(event) && lacksUserId(event)) {
-            ctx.output(DLQ_TAG, new DeadLetterEvent(
-                    event.toString(),
-                    "user_id unresolvable after schema normalization (version=" + event.schemaVersion + ")"));
+    public void processElement(CdcEvent event, Context ctx, Collector<CdcEvent> out) {
+        if (event == null) {
             return;
         }
+
+        DeadLetterEvent dlqEntry = classify(event);
+        if (dlqEntry != null) {
+            ctx.output(DLQ_TAG, dlqEntry);
+            return;
+        }
+
         out.collect(event);
+    }
+
+    // ── Routing logic (package-private for unit testing) ─────────────────────
+
+    /**
+     * Classifies {@code event} and returns a {@link DeadLetterEvent} if it must be
+     * routed to the DLQ, or {@code null} if it should pass through.
+     */
+    static DeadLetterEvent classify(CdcEvent event) {
+        // Check for BREAKING schema changes detected during deserialization
+        List<SchemaChange> breaking = breakingChanges(event.detectedChanges);
+        if (!breaking.isEmpty()) {
+            SchemaChange first = breaking.get(0);
+            return new DeadLetterEvent(
+                    event.toString(),
+                    buildMessage(first),
+                    first.changeType,
+                    event.schemaVersion,
+                    first.column,
+                    first.effectiveCompatibility);
+        }
+
+        // Inserts/reads missing the required user_id field
+        if (isInsertOrRead(event) && lacksUserId(event)) {
+            return new DeadLetterEvent(
+                    event.toString(),
+                    "user_id unresolvable after schema normalization (version=" + event.schemaVersion + ")",
+                    ChangeType.DROP_COLUMN,
+                    event.schemaVersion,
+                    "user_id",
+                    CompatibilityLevel.BREAKING);
+        }
+
+        return null;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static List<SchemaChange> breakingChanges(List<SchemaChange> changes) {
+        if (changes == null) return List.of();
+        return changes.stream()
+                .filter(c -> c.effectiveCompatibility == CompatibilityLevel.BREAKING)
+                .toList();
+    }
+
+    private static String buildMessage(SchemaChange change) {
+        return String.format(
+                "BREAKING schema change detected: %s on column '%s' (%s → %s). "
+                + "Register an alias or fix the source schema, then replay from the DLQ.",
+                change.changeType, change.column, change.oldTypeHint, change.newTypeHint);
     }
 
     private static boolean isInsertOrRead(CdcEvent event) {

--- a/stream-processor/src/main/java/ai/streamforge/processor/deserialization/SchemaEvolutionHandler.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/deserialization/SchemaEvolutionHandler.java
@@ -2,29 +2,55 @@ package ai.streamforge.processor.deserialization;
 
 import ai.streamforge.processor.model.CdcEvent;
 import ai.streamforge.processor.model.SchemaVersion;
+import ai.streamforge.processor.schema.ChangeType;
+import ai.streamforge.processor.schema.ColumnAliasRegistry;
+import ai.streamforge.processor.schema.SchemaChange;
+import ai.streamforge.processor.schema.TypeCompatibilityChecker;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Stateless utility that normalizes a raw Debezium JSON payload into a
- * {@link CdcEvent}, handling field aliases introduced by schema renames and
- * detecting which schema version the event conforms to.
+ * {@link CdcEvent}, handling schema evolution across four change categories:
  *
- * <h3>Field aliases</h3>
- * <table border="1">
- *   <tr><th>Canonical field</th><th>Accepted aliases</th></tr>
- *   <tr><td>user_id</td><td>uid</td></tr>
- *   <tr><td>event_type</td><td>type</td></tr>
- *   <tr><td>created_at</td><td>ts</td></tr>
- * </table>
+ * <h3>1. Column add</h3>
+ * New nullable columns ({@code session_id}, {@code ip_address}, {@code metadata})
+ * are silently null-filled for events that pre-date the DDL change.
+ * Compatibility: <b>FULL</b>.
  *
- * <h3>Schema versions</h3>
+ * <h3>2. Column drop</h3>
+ * A dropped column simply becomes absent in the JSON — the row field is null-filled.
+ * If the dropped column was a <em>required</em> field ({@code user_id}) the event is
+ * flagged with {@link ChangeType#DROP_COLUMN} and routed to the DLQ by
+ * {@link SchemaEvolutionFilter}.
+ * Compatibility: <b>FORWARD</b> (optional) / <b>BREAKING</b> (required).
+ *
+ * <h3>3. Column rename</h3>
+ * The {@link ColumnAliasRegistry} maps legacy names to canonical names.
+ * Built-in aliases: {@code uid → user_id}, {@code type → event_type},
+ * {@code ts → created_at}.  Additional aliases may be registered at runtime
+ * via the {@code COLUMN_ALIASES} env var ({@code oldName=newName,...}).
+ * An unregistered rename is treated as {@code DROP_COLUMN} on the canonical field
+ * (routed to DLQ if required).
+ * Compatibility: <b>BACKWARD</b> (with alias) / <b>BREAKING</b> (without).
+ *
+ * <h3>4. Type widening</h3>
+ * Numeric widenings (e.g. INT → BIGINT for {@code created_at}) are detected by
+ * {@link TypeCompatibilityChecker}.  The event is annotated and passes through.
+ * Incompatible type changes (numeric → string) are routed to the DLQ.
+ * Compatibility: <b>BACKWARD</b> (widening) / <b>BREAKING</b> (incompatible).
+ *
+ * <h3>Schema version detection</h3>
  * <ul>
- *   <li>{@link SchemaVersion#V1} — original columns: user_id, event_type, created_at</li>
- *   <li>{@link SchemaVersion#V2} — adds session_id and ip_address (both nullable)</li>
- *   <li>{@link SchemaVersion#UNKNOWN} — after payload absent or key fields missing</li>
+ *   <li><b>V1</b> — only core fields: {@code user_id}/{@code uid}, {@code event_type},
+ *       {@code created_at}.</li>
+ *   <li><b>V2</b> — adds {@code session_id} and/or {@code ip_address}.</li>
+ *   <li><b>V3</b> — adds {@code metadata} blob or {@code created_at} overflows int range.</li>
+ *   <li><b>UNKNOWN</b> — {@code after} absent or no known key field found.</li>
  * </ul>
  */
 public final class SchemaEvolutionHandler {
@@ -32,11 +58,23 @@ public final class SchemaEvolutionHandler {
     private SchemaEvolutionHandler() {}
 
     /**
-     * Parses {@code bytes} into a {@link CdcEvent} with schema normalization applied.
+     * Parses {@code bytes} into a {@link CdcEvent} with full schema normalization.
+     * Uses the default alias registry (built-ins + {@code COLUMN_ALIASES} env var).
      *
      * @throws IOException if the bytes are not valid JSON
      */
     public static CdcEvent handle(byte[] bytes, ObjectMapper mapper) throws IOException {
+        return handle(bytes, mapper, ColumnAliasRegistry.withDefaults());
+    }
+
+    /**
+     * Parses {@code bytes} using a caller-supplied {@link ColumnAliasRegistry}.
+     * Useful in tests to supply a controlled alias set.
+     *
+     * @throws IOException if the bytes are not valid JSON
+     */
+    public static CdcEvent handle(
+            byte[] bytes, ObjectMapper mapper, ColumnAliasRegistry aliases) throws IOException {
         JsonNode root = mapper.readTree(bytes);
 
         CdcEvent event = new CdcEvent();
@@ -45,8 +83,10 @@ public final class SchemaEvolutionHandler {
 
         JsonNode afterNode = root.path("after");
         if (!afterNode.isMissingNode() && !afterNode.isNull()) {
-            event.after         = normalizeRow(afterNode);
-            event.schemaVersion = detectVersion(afterNode);
+            List<SchemaChange> changes = new ArrayList<>();
+            event.after           = normalizeRow(afterNode, aliases, changes);
+            event.detectedChanges = changes;
+            event.schemaVersion   = detectVersion(afterNode, event.after);
         } else {
             event.schemaVersion = SchemaVersion.UNKNOWN;
         }
@@ -56,11 +96,19 @@ public final class SchemaEvolutionHandler {
 
     // ── Version detection ────────────────────────────────────────────────────
 
-    static SchemaVersion detectVersion(JsonNode afterNode) {
+    static SchemaVersion detectVersion(JsonNode afterNode, CdcEvent.UserEventRow row) {
+        // V3: metadata blob present, or created_at overflows 32-bit int range
+        if (afterNode.has("metadata")
+                || (row.createdAt != null
+                    && (row.createdAt > Integer.MAX_VALUE || row.createdAt < Integer.MIN_VALUE))) {
+            return SchemaVersion.V3;
+        }
+        // V2: session_id or ip_address present
         if (afterNode.has("session_id") || afterNode.has("ip_address")) {
             return SchemaVersion.V2;
         }
-        if (afterNode.has("user_id") || afterNode.has("uid")) {
+        // V1: at least one core canonical field (or its alias) resolved
+        if (row.userId != null || row.eventType != null) {
             return SchemaVersion.V1;
         }
         return SchemaVersion.UNKNOWN;
@@ -68,42 +116,90 @@ public final class SchemaEvolutionHandler {
 
     // ── Field normalization ──────────────────────────────────────────────────
 
-    static CdcEvent.UserEventRow normalizeRow(JsonNode afterNode) {
+    static CdcEvent.UserEventRow normalizeRow(
+            JsonNode afterNode, ColumnAliasRegistry aliases, List<SchemaChange> changes) {
         CdcEvent.UserEventRow row = new CdcEvent.UserEventRow();
-        // user_id — also accepts legacy alias "uid" (column renamed in some deployments)
-        row.userId    = coalesceText(afterNode, "user_id", "uid");
-        // event_type — also accepts abbreviated alias "type"
-        row.eventType = coalesceText(afterNode, "event_type", "type");
-        // created_at — also accepts shortened alias "ts"
-        row.createdAt = coalesceTimestamp(afterNode, "created_at", "ts");
-        // V2 fields (nullable; null when absent in V1 payloads)
+
+        // user_id — accepts registered aliases (built-in: uid)
+        row.userId = resolveText(afterNode, aliases, "user_id");
+        if (row.userId == null && !hasFieldOrAlias(afterNode, aliases, "user_id")) {
+            // Required field absent — signal a DROP of a required column
+            changes.add(new SchemaChange("user_id", "string", null, ChangeType.DROP_COLUMN));
+        }
+
+        // event_type — accepts registered aliases (built-in: type)
+        row.eventType = resolveText(afterNode, aliases, "event_type");
+
+        // created_at — accepts registered aliases (built-in: ts); check for type widening
+        row.createdAt = resolveTimestamp(afterNode, aliases, changes, "created_at");
+
+        // V2 fields — null when absent (compatible add; no change recorded)
         row.sessionId = textOrNull(afterNode, "session_id");
         row.ipAddress = textOrNull(afterNode, "ip_address");
+
+        // V3 fields — null when absent (compatible add)
+        row.metadata = textOrNull(afterNode, "metadata");
+
         return row;
     }
 
-    // ── Helpers ──────────────────────────────────────────────────────────────
+    // ── Resolution helpers ───────────────────────────────────────────────────
 
-    /** Returns the text value of the first non-null key found among {@code keys}. */
-    static String coalesceText(JsonNode node, String... keys) {
-        for (String key : keys) {
-            String val = textOrNull(node, key);
-            if (val != null) {
-                return val;
+    /**
+     * Returns the text value of {@code canonical} or any alias that maps to it.
+     * Canonical field takes priority over aliases.
+     */
+    static String resolveText(JsonNode node, ColumnAliasRegistry aliases, String canonical) {
+        // Try the canonical name first
+        String val = textOrNull(node, canonical);
+        if (val != null) return val;
+
+        // Try every registered alias that maps to this canonical
+        for (java.util.Map.Entry<String, String> entry : aliases.allAliases().entrySet()) {
+            if (canonical.equals(entry.getValue())) {
+                val = textOrNull(node, entry.getKey());
+                if (val != null) return val;
             }
         }
         return null;
     }
 
-    /** Returns the long value of the first non-null key found among {@code keys}. */
-    static Long coalesceTimestamp(JsonNode node, String... keys) {
-        for (String key : keys) {
-            JsonNode child = node.get(key);
-            if (child != null && !child.isNull()) {
-                return child.asLong();
+    /**
+     * Returns the long timestamp for {@code canonical} or any registered alias.
+     * Appends a {@link ChangeType#WIDEN_TYPE} or {@link ChangeType#INCOMPATIBLE_TYPE}
+     * change to {@code changes} if the value deviates from the expected int type.
+     */
+    static Long resolveTimestamp(
+            JsonNode node,
+            ColumnAliasRegistry aliases,
+            List<SchemaChange> changes,
+            String canonical) {
+        JsonNode child = node.get(canonical);
+        if (child == null || child.isNull()) {
+            // Try aliases
+            for (java.util.Map.Entry<String, String> entry : aliases.allAliases().entrySet()) {
+                if (canonical.equals(entry.getValue())) {
+                    child = node.get(entry.getKey());
+                    if (child != null && !child.isNull()) break;
+                }
             }
         }
-        return null;
+        if (child == null || child.isNull()) return null;
+
+        SchemaChange typeChange = TypeCompatibilityChecker.check(canonical, child, "int");
+        if (typeChange != null) {
+            changes.add(typeChange);
+        }
+        return child.asLong();
+    }
+
+    /** Returns {@code true} if the canonical field or any alias mapping to it is present in the node. */
+    static boolean hasFieldOrAlias(JsonNode node, ColumnAliasRegistry aliases, String canonical) {
+        if (node.has(canonical)) return true;
+        for (java.util.Map.Entry<String, String> entry : aliases.allAliases().entrySet()) {
+            if (canonical.equals(entry.getValue()) && node.has(entry.getKey())) return true;
+        }
+        return false;
     }
 
     static String textOrNull(JsonNode node, String field) {

--- a/stream-processor/src/main/java/ai/streamforge/processor/model/CdcEvent.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/model/CdcEvent.java
@@ -1,7 +1,11 @@
 package ai.streamforge.processor.model;
 
+import ai.streamforge.processor.schema.SchemaChange;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Debezium CDC envelope for a MySQL row change event.
@@ -29,6 +33,13 @@ public class CdcEvent {
      */
     public transient SchemaVersion schemaVersion = SchemaVersion.UNKNOWN;
 
+    /**
+     * Schema changes detected during deserialization of this event (e.g. type widenings).
+     * Non-empty only when the handler detects a deviation from the expected schema.
+     * Transient — for in-process routing only.
+     */
+    public transient List<SchemaChange> detectedChanges = new ArrayList<>();
+
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class UserEventRow {
 
@@ -49,5 +60,9 @@ public class CdcEvent {
         /** V2+: client IP address (nullable). */
         @JsonProperty("ip_address")
         public String ipAddress;
+
+        /** V3+: arbitrary metadata JSON blob (nullable). */
+        @JsonProperty("metadata")
+        public String metadata;
     }
 }

--- a/stream-processor/src/main/java/ai/streamforge/processor/model/DeadLetterEvent.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/model/DeadLetterEvent.java
@@ -1,22 +1,83 @@
 package ai.streamforge.processor.model;
 
-/** A CDC record that could not be processed; routed to the dead-letter Kafka topic. */
+import ai.streamforge.processor.schema.ChangeType;
+import ai.streamforge.processor.schema.CompatibilityLevel;
+
+/**
+ * A CDC record that could not be processed; routed to the dead-letter Kafka topic.
+ *
+ * <p>The {@link #changeType} and {@link #schemaVersion} fields carry enough context
+ * for an operator to determine the remediation path:
+ * <ul>
+ *   <li>{@link ChangeType#DROP_COLUMN} on a required field →
+ *       register an alias or fix the source schema; then replay from this offset.</li>
+ *   <li>{@link ChangeType#RENAME_COLUMN} →
+ *       register an alias via {@code COLUMN_ALIASES} env var; take a savepoint and
+ *       redeploy; then use the {@code DlqReprocessingJob} to replay this event.</li>
+ *   <li>{@link ChangeType#INCOMPATIBLE_TYPE} →
+ *       fix the source schema; full reprocessing from earliest offset may be needed.</li>
+ * </ul>
+ */
 public class DeadLetterEvent {
 
+    /** Raw JSON bytes of the original Debezium envelope. */
     public String rawPayload;
+
+    /** Human-readable description of why the event was rejected. */
     public String errorMessage;
+
+    /** Epoch-ms when this DLQ entry was created. */
     public long failedAtMs;
+
+    /**
+     * Type of schema change that caused the rejection, or {@code null} if the failure
+     * was a parse error unrelated to schema evolution.
+     */
+    public ChangeType changeType;
+
+    /**
+     * Schema version detected before the event was rejected.
+     * Helps correlate DLQ spikes with specific DDL migrations.
+     */
+    public SchemaVersion schemaVersion;
+
+    /** Column affected by the change, if known. */
+    public String affectedColumn;
+
+    /** Effective compatibility level of the detected change. */
+    public CompatibilityLevel compatibilityLevel;
 
     public DeadLetterEvent() {}
 
     public DeadLetterEvent(String rawPayload, String errorMessage) {
-        this.rawPayload = rawPayload;
+        this.rawPayload   = rawPayload;
         this.errorMessage = errorMessage;
-        this.failedAtMs = System.currentTimeMillis();
+        this.failedAtMs   = System.currentTimeMillis();
+    }
+
+    public DeadLetterEvent(
+            String rawPayload,
+            String errorMessage,
+            ChangeType changeType,
+            SchemaVersion schemaVersion,
+            String affectedColumn,
+            CompatibilityLevel compatibilityLevel) {
+        this(rawPayload, errorMessage);
+        this.changeType         = changeType;
+        this.schemaVersion      = schemaVersion;
+        this.affectedColumn     = affectedColumn;
+        this.compatibilityLevel = compatibilityLevel;
     }
 
     @Override
     public String toString() {
-        return "DeadLetterEvent{error='" + errorMessage + "', failedAtMs=" + failedAtMs + "}";
+        return "DeadLetterEvent{"
+                + "error='" + errorMessage + '\''
+                + ", changeType=" + changeType
+                + ", schemaVersion=" + schemaVersion
+                + ", affectedColumn='" + affectedColumn + '\''
+                + ", compatibility=" + compatibilityLevel
+                + ", failedAtMs=" + failedAtMs
+                + '}';
     }
 }

--- a/stream-processor/src/main/java/ai/streamforge/processor/model/SchemaVersion.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/model/SchemaVersion.java
@@ -3,12 +3,22 @@ package ai.streamforge.processor.model;
 /**
  * Tracks the schema version of an incoming {@link CdcEvent}, detected from
  * which fields are present in the Debezium {@code after} payload.
+ *
+ * <h3>Version history</h3>
+ * <ul>
+ *   <li><b>V1</b> — Original schema: {@code user_id}, {@code event_type}, {@code created_at}.</li>
+ *   <li><b>V2</b> — Adds {@code session_id} and {@code ip_address} (both nullable).</li>
+ *   <li><b>V3</b> — Widens {@code created_at} from INT to BIGINT (millisecond epoch);
+ *       also adds {@code metadata} JSON blob (nullable). Detected when
+ *       {@code created_at} overflows 32-bit range or {@code metadata} is present.</li>
+ *   <li><b>UNKNOWN</b> — Fields don't match any known version; treated as V1 with
+ *       nulls for missing fields.  Events landing here are also routed to the DLQ
+ *       by {@link ai.streamforge.processor.deserialization.SchemaEvolutionFilter}.</li>
+ * </ul>
  */
 public enum SchemaVersion {
-    /** Original schema: user_id, event_type, created_at. */
     V1,
-    /** Extended schema: adds session_id and ip_address (both nullable). */
     V2,
-    /** Fields don't match any known version; treated as V1 with nulls for missing fields. */
+    V3,
     UNKNOWN
 }

--- a/stream-processor/src/main/java/ai/streamforge/processor/reprocessing/DlqReprocessingJob.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/reprocessing/DlqReprocessingJob.java
@@ -1,0 +1,191 @@
+package ai.streamforge.processor.reprocessing;
+
+import ai.streamforge.processor.deserialization.SchemaAwareCdcDeserializationSchema;
+import ai.streamforge.processor.deserialization.SchemaEvolutionFilter;
+import ai.streamforge.processor.model.CdcEvent;
+import ai.streamforge.processor.model.DeadLetterEvent;
+import ai.streamforge.processor.schema.ColumnAliasRegistry;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.api.common.eventtime.WatermarkStrategy;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * One-shot Flink job that replays events from the dead-letter topic back into
+ * the main CDC pipeline after a BREAKING schema change has been remediated.
+ *
+ * <h3>When to run</h3>
+ * <ol>
+ *   <li>A BREAKING change (column rename, incompatible type) caused events to land in
+ *       the DLQ ({@code KAFKA_DLQ_TOPIC}).</li>
+ *   <li>The alias or coercion rule has been registered
+ *       (via {@code COLUMN_ALIASES} env var or code change).</li>
+ *   <li>The main {@code CdcUserEventCountJob} has been redeployed from a savepoint
+ *       with the updated alias registry.</li>
+ *   <li>This job is submitted <em>once</em> to drain the DLQ.  It reads each
+ *       {@link DeadLetterEvent}, extracts the {@code rawPayload}, re-deserializes it
+ *       with the updated alias registry, and publishes valid events back to the
+ *       source topic.</li>
+ * </ol>
+ *
+ * <h3>Idempotency</h3>
+ * Replayed events carry the original {@code ts_ms} value so watermark-based
+ * event-time windows in the main job can place them in the correct window.
+ * The main job's checkpoint interval and out-of-orderness allowance must be set
+ * large enough to absorb the replay.  For large backlogs, consider running the
+ * main job with {@code KAFKA_RESET_OFFSETS=earliest} instead of replaying through
+ * the DLQ.
+ *
+ * <h3>Configuration (env vars)</h3>
+ * <ul>
+ *   <li>{@code KAFKA_BOOTSTRAP_SERVERS}  — default {@code localhost:9092}</li>
+ *   <li>{@code KAFKA_DLQ_TOPIC}          — default {@code cdc.dead.letter}</li>
+ *   <li>{@code KAFKA_SOURCE_TOPIC}       — re-injection target, default {@code cdc.streamforge.user_events}</li>
+ *   <li>{@code KAFKA_CONSUMER_GROUP}     — default {@code flink-dlq-reprocessor}</li>
+ *   <li>{@code COLUMN_ALIASES}           — comma-separated {@code alias=canonical} pairs</li>
+ *   <li>{@code REPROCESS_MAX_EVENTS}     — safety cap; 0 = unlimited (default {@code 0})</li>
+ * </ul>
+ */
+public class DlqReprocessingJob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DlqReprocessingJob.class);
+
+    public static void main(String[] args) throws Exception {
+        String bootstrapServers = env("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092");
+        String dlqTopic         = env("KAFKA_DLQ_TOPIC",         "cdc.dead.letter");
+        String sourceTopic      = env("KAFKA_SOURCE_TOPIC",      "cdc.streamforge.user_events");
+        String consumerGroup    = env("KAFKA_CONSUMER_GROUP",    "flink-dlq-reprocessor");
+        long   maxEvents        = Long.parseLong(env("REPROCESS_MAX_EVENTS", "0"));
+
+        LOG.info("DlqReprocessingJob starting: dlq={} → source={}, aliases={}",
+                dlqTopic, sourceTopic, System.getenv("COLUMN_ALIASES"));
+
+        ColumnAliasRegistry aliases = ColumnAliasRegistry.withDefaults();
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(15_000);
+
+        // Read raw bytes from DLQ — the topic stores DeadLetterEvent JSON
+        KafkaSource<byte[]> dlqSource = KafkaSource.<byte[]>builder()
+                .setBootstrapServers(bootstrapServers)
+                .setTopics(dlqTopic)
+                .setGroupId(consumerGroup)
+                .setStartingOffsets(OffsetsInitializer.earliest())
+                .setValueOnlyDeserializer(new RawBytesDeserializationSchema())
+                .setBounded(OffsetsInitializer.latest()) // drain-and-stop
+                .build();
+
+        DataStream<byte[]> dlqStream = env.fromSource(
+                dlqSource,
+                WatermarkStrategy.noWatermarks(),
+                "Kafka DLQ Source: " + dlqTopic);
+
+        // Extract rawPayload from each DeadLetterEvent, re-deserialize with updated aliases
+        ObjectMapper mapper = new ObjectMapper();
+
+        SingleOutputStreamOperator<CdcEvent> reprocessed = dlqStream
+                .flatMap((bytes, out) -> {
+                    try {
+                        JsonNode dlqEvent = mapper.readTree(bytes);
+                        String rawPayload = dlqEvent.path("rawPayload").asText(null);
+                        if (rawPayload == null || rawPayload.isBlank()) {
+                            LOG.warn("DLQ event missing rawPayload, skipping");
+                            return;
+                        }
+                        CdcEvent event = ai.streamforge.processor.deserialization
+                                .SchemaEvolutionHandler.handle(
+                                        rawPayload.getBytes(java.nio.charset.StandardCharsets.UTF_8),
+                                        mapper, aliases);
+                        if (event != null) {
+                            out.collect(event);
+                        }
+                    } catch (Exception e) {
+                        LOG.error("Failed to re-deserialize DLQ record: {}", e.getMessage());
+                    }
+                })
+                .returns(TypeInformation.of(CdcEvent.class))
+                .name("Re-deserialize with updated aliases");
+
+        // Route through the same schema evolution filter — events that are still
+        // BREAKING after alias update land back in a secondary DLQ for manual review
+        SingleOutputStreamOperator<CdcEvent> filtered = reprocessed
+                .process(new SchemaEvolutionFilter())
+                .name("Schema Evolution Filter (reprocessing)");
+
+        DataStream<DeadLetterEvent> stillBroken =
+                filtered.getSideOutput(SchemaEvolutionFilter.DLQ_TAG);
+
+        String secondaryDlqTopic = dlqTopic + ".unresolved";
+        KafkaSink<DeadLetterEvent> secondaryDlq = KafkaSink.<DeadLetterEvent>builder()
+                .setBootstrapServers(bootstrapServers)
+                .setRecordSerializer(
+                        KafkaRecordSerializationSchema.<DeadLetterEvent>builder()
+                                .setTopic(secondaryDlqTopic)
+                                .setValueSerializationSchema(
+                                        new ai.streamforge.processor.serialization
+                                                .DeadLetterEventSerializationSchema())
+                                .build())
+                .build();
+        stillBroken.sinkTo(secondaryDlq).name("Secondary DLQ: " + secondaryDlqTopic);
+        LOG.info("Unresolvable events will be routed to {}", secondaryDlqTopic);
+
+        // Re-inject successfully re-processed events into the main source topic
+        KafkaSink<CdcEvent> reinjectSink = KafkaSink.<CdcEvent>builder()
+                .setBootstrapServers(bootstrapServers)
+                .setRecordSerializer(
+                        KafkaRecordSerializationSchema.<CdcEvent>builder()
+                                .setTopic(sourceTopic)
+                                .setValueSerializationSchema(new CdcEventSerializationSchema())
+                                .build())
+                .build();
+        filtered.sinkTo(reinjectSink).name("Re-inject to: " + sourceTopic);
+
+        env.execute("DlqReprocessingJob");
+    }
+
+    // ── Serialization schemas ────────────────────────────────────────────────
+
+    /** Passes raw Kafka message bytes through unchanged. */
+    static class RawBytesDeserializationSchema implements DeserializationSchema<byte[]> {
+        @Override public byte[]  deserialize(byte[] message)       { return message; }
+        @Override public boolean isEndOfStream(byte[] nextElement)  { return false; }
+        @Override public TypeInformation<byte[]> getProducedType() {
+            return TypeInformation.of(byte[].class);
+        }
+    }
+
+    /** Serializes a {@link CdcEvent} back to its original JSON bytes for re-injection. */
+    static class CdcEventSerializationSchema implements SerializationSchema<CdcEvent> {
+        private transient ObjectMapper mapper;
+
+        @Override
+        public void open(InitializationContext context) {
+            mapper = new ObjectMapper();
+        }
+
+        @Override
+        public byte[] serialize(CdcEvent event) {
+            try {
+                return mapper.writeValueAsBytes(event);
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to serialize CdcEvent for re-injection", e);
+            }
+        }
+    }
+
+    private static String env(String name, String defaultValue) {
+        String v = System.getenv(name);
+        return (v != null && !v.isBlank()) ? v : defaultValue;
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/schema/ChangeType.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/schema/ChangeType.java
@@ -1,0 +1,56 @@
+package ai.streamforge.processor.schema;
+
+/**
+ * Taxonomy of schema changes Debezium can surface via CDC events.
+ *
+ * Each value carries a pre-computed {@link CompatibilityLevel} that reflects
+ * the *default* classification before any alias or coercion rule is applied.
+ * After a rule is registered (e.g. a column alias for a rename) the change
+ * may be re-classified as BACKWARD.
+ */
+public enum ChangeType {
+
+    /** New nullable column added to the table. Old events lack the field → null-filled. */
+    ADD_COLUMN(CompatibilityLevel.FULL),
+
+    /**
+     * Column removed from the table.
+     * Compatible if the column is optional in the processing logic (null-safe).
+     * Breaking if the column is required (e.g. user_id).
+     */
+    DROP_COLUMN(CompatibilityLevel.FORWARD),
+
+    /**
+     * Column renamed without a registered alias.
+     * Events written under the new name will miss the old canonical field name.
+     * After the alias is registered this degrades to ADD_COLUMN + DROP_COLUMN.
+     */
+    RENAME_COLUMN(CompatibilityLevel.BREAKING),
+
+    /**
+     * Numeric type widened (e.g. INT → BIGINT, FLOAT → DOUBLE).
+     * Old values always fit in the wider type; Flink reads them as longs/doubles.
+     */
+    WIDEN_TYPE(CompatibilityLevel.BACKWARD),
+
+    /**
+     * Numeric type narrowed (e.g. BIGINT → INT).
+     * Values that exceed the narrower range will overflow or truncate.
+     */
+    NARROW_TYPE(CompatibilityLevel.BREAKING),
+
+    /**
+     * Column type changed in a structurally incompatible way (e.g. INT → VARCHAR).
+     * JSON representation changes; downstream parsing will fail.
+     */
+    INCOMPATIBLE_TYPE(CompatibilityLevel.BREAKING),
+
+    /** Change could not be classified — treat conservatively as BREAKING. */
+    UNKNOWN(CompatibilityLevel.BREAKING);
+
+    public final CompatibilityLevel defaultCompatibility;
+
+    ChangeType(CompatibilityLevel level) {
+        this.defaultCompatibility = level;
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/schema/ColumnAliasRegistry.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/schema/ColumnAliasRegistry.java
@@ -1,0 +1,156 @@
+package ai.streamforge.processor.schema;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Registry that maps legacy or renamed column names to their current canonical names.
+ *
+ * <h3>Purpose</h3>
+ * When Debezium captures a column rename ({@code ALTER TABLE … CHANGE COLUMN}),
+ * events written before the rename carry the old column name and events written
+ * after carry the new one.  Registering an alias lets the deserialization layer
+ * normalize both to the same canonical field name, turning a BREAKING rename into
+ * a transparent BACKWARD-compatible migration.
+ *
+ * <h3>Built-in aliases</h3>
+ * <ul>
+ *   <li>{@code uid}  → {@code user_id}   (historical rename)</li>
+ *   <li>{@code type} → {@code event_type} (historical rename)</li>
+ *   <li>{@code ts}   → {@code created_at} (historical rename)</li>
+ * </ul>
+ *
+ * <h3>Runtime registration</h3>
+ * New aliases can be added at runtime via {@link #register(String, String)} or
+ * bulk-loaded from the environment variable {@code COLUMN_ALIASES} (format:
+ * {@code alias1=canonical1,alias2=canonical2}).  This allows operators to deploy
+ * an alias without recompiling or restarting the Flink job from scratch — a
+ * savepoint-restore cycle is sufficient.
+ */
+public final class ColumnAliasRegistry implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(ColumnAliasRegistry.class);
+
+    /** alias → canonical column name */
+    private final Map<String, String> aliases;
+
+    // ── Factory ──────────────────────────────────────────────────────────────
+
+    /** Returns a registry pre-loaded with built-in aliases and any from the env var. */
+    public static ColumnAliasRegistry withDefaults() {
+        ColumnAliasRegistry registry = new ColumnAliasRegistry();
+        registry.registerBuiltins();
+        registry.loadFromEnv(System.getenv("COLUMN_ALIASES"));
+        return registry;
+    }
+
+    /** Returns a registry with *only* the built-in aliases (useful in tests). */
+    public static ColumnAliasRegistry builtinsOnly() {
+        ColumnAliasRegistry registry = new ColumnAliasRegistry();
+        registry.registerBuiltins();
+        return registry;
+    }
+
+    /** Returns an empty registry (no built-ins). */
+    public static ColumnAliasRegistry empty() {
+        return new ColumnAliasRegistry();
+    }
+
+    private ColumnAliasRegistry() {
+        this.aliases = new LinkedHashMap<>();
+    }
+
+    // ── Registration ─────────────────────────────────────────────────────────
+
+    /**
+     * Registers {@code alias} as an alternative name for {@code canonical}.
+     *
+     * @param alias     the old / alternative column name that may appear in events
+     * @param canonical the authoritative column name used by the processing logic
+     */
+    public void register(String alias, String canonical) {
+        if (alias == null || canonical == null || alias.isBlank() || canonical.isBlank()) {
+            throw new IllegalArgumentException("alias and canonical must be non-blank");
+        }
+        String prev = aliases.put(alias.trim(), canonical.trim());
+        if (prev != null && !prev.equals(canonical)) {
+            LOG.warn("Column alias '{}' re-registered: '{}' → '{}'", alias, prev, canonical);
+        }
+    }
+
+    /**
+     * Parses and loads aliases from {@code spec}.
+     * Format: {@code alias1=canonical1,alias2=canonical2}.
+     * Silently ignores malformed entries.
+     */
+    public void loadFromEnv(String spec) {
+        if (spec == null || spec.isBlank()) {
+            return;
+        }
+        for (String pair : spec.split(",")) {
+            String[] parts = pair.split("=", 2);
+            if (parts.length == 2 && !parts[0].isBlank() && !parts[1].isBlank()) {
+                register(parts[0].trim(), parts[1].trim());
+                LOG.info("Loaded column alias from env: '{}' → '{}'", parts[0].trim(), parts[1].trim());
+            } else {
+                LOG.warn("Skipping malformed COLUMN_ALIASES entry: '{}'", pair);
+            }
+        }
+    }
+
+    // ── Lookup ───────────────────────────────────────────────────────────────
+
+    /**
+     * Resolves {@code columnName} to its canonical name.
+     * If {@code columnName} is itself canonical (or has no registered alias),
+     * it is returned unchanged.
+     */
+    public String resolve(String columnName) {
+        return aliases.getOrDefault(columnName, columnName);
+    }
+
+    /**
+     * Returns the canonical name for the first non-null alternative found in
+     * {@code candidates}.  Useful for coalescing across multiple possible names.
+     *
+     * @return the first non-null candidate after alias resolution, or {@code null}
+     */
+    public String resolveFirstPresent(Map<String, Object> row, String... candidates) {
+        for (String candidate : candidates) {
+            if (row.containsKey(candidate)) {
+                return candidate;
+            }
+            // check if any registered alias resolves to this candidate
+            for (Map.Entry<String, String> e : aliases.entrySet()) {
+                if (e.getValue().equals(candidate) && row.containsKey(e.getKey())) {
+                    return e.getKey();
+                }
+            }
+        }
+        return null;
+    }
+
+    /** Returns {@code true} if the registry knows about this alias. */
+    public boolean isAlias(String columnName) {
+        return aliases.containsKey(columnName);
+    }
+
+    /** Returns an unmodifiable view of all registered aliases for diagnostics. */
+    public Map<String, String> allAliases() {
+        return Collections.unmodifiableMap(aliases);
+    }
+
+    // ── Internal ─────────────────────────────────────────────────────────────
+
+    private void registerBuiltins() {
+        register("uid",  "user_id");
+        register("type", "event_type");
+        register("ts",   "created_at");
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/schema/CompatibilityLevel.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/schema/CompatibilityLevel.java
@@ -1,0 +1,29 @@
+package ai.streamforge.processor.schema;
+
+/**
+ * Compatibility classification for a Debezium schema change.
+ *
+ * <pre>
+ * BACKWARD  – new schema can read data written with the old schema.
+ *             Flink job keeps running; null-fill / alias handles gaps.
+ *             Example: ADD COLUMN (nullable), type widening (INT → BIGINT).
+ *
+ * FORWARD   – old schema can read data written with the new schema
+ *             (unknown fields are silently ignored by {@code @JsonIgnoreProperties}).
+ *             Example: DROP COLUMN that is optional in processing logic.
+ *
+ * FULL      – both BACKWARD and FORWARD; the safest possible change.
+ *             Example: ADD COLUMN nullable with a registered default.
+ *
+ * BREAKING  – neither direction is safe without intervention.
+ *             Flink job must be stopped; events land in the DLQ.
+ *             Reprocessing is required after the alias or coercion rule is registered.
+ *             Example: DROP required column, type narrowing, rename without alias.
+ * </pre>
+ */
+public enum CompatibilityLevel {
+    BACKWARD,
+    FORWARD,
+    FULL,
+    BREAKING
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/schema/SchemaChange.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/schema/SchemaChange.java
@@ -1,0 +1,68 @@
+package ai.streamforge.processor.schema;
+
+import java.io.Serializable;
+
+/**
+ * Describes a single schema change detected from a CDC event's field presence
+ * or type signature.
+ *
+ * <p>Instances are attached to {@link ai.streamforge.processor.model.DeadLetterEvent}
+ * when a BREAKING change is detected, providing enough context for an operator to
+ * register an alias or coercion rule and trigger reprocessing.
+ */
+public final class SchemaChange implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    /** Column (field) affected by the change. */
+    public final String column;
+
+    /** Human-readable description of the observed type before the change, if known. */
+    public final String oldTypeHint;
+
+    /** Human-readable description of the observed type after the change, if known. */
+    public final String newTypeHint;
+
+    /** Classification of this specific change. */
+    public final ChangeType changeType;
+
+    /** Effective compatibility after alias/coercion rules are applied. */
+    public final CompatibilityLevel effectiveCompatibility;
+
+    public SchemaChange(
+            String column,
+            String oldTypeHint,
+            String newTypeHint,
+            ChangeType changeType) {
+        this.column = column;
+        this.oldTypeHint = oldTypeHint;
+        this.newTypeHint = newTypeHint;
+        this.changeType = changeType;
+        this.effectiveCompatibility = changeType.defaultCompatibility;
+    }
+
+    /** Returns a new instance with an updated effective compatibility (e.g. after alias registration). */
+    public SchemaChange withCompatibility(CompatibilityLevel level) {
+        return new SchemaChange(column, oldTypeHint, newTypeHint, changeType) {
+            { /* shadow the field via anonymous-class initialiser */ }
+            @Override public String toString() {
+                return SchemaChange.this.toStringWith(level);
+            }
+        };
+    }
+
+    @Override
+    public String toString() {
+        return toStringWith(effectiveCompatibility);
+    }
+
+    private String toStringWith(CompatibilityLevel level) {
+        return "SchemaChange{"
+                + "column='" + column + '\''
+                + ", changeType=" + changeType
+                + ", compatibility=" + level
+                + ", oldType='" + oldTypeHint + '\''
+                + ", newType='" + newTypeHint + '\''
+                + '}';
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/schema/TypeCompatibilityChecker.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/schema/TypeCompatibilityChecker.java
@@ -1,0 +1,147 @@
+package ai.streamforge.processor.schema;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Classifies the type compatibility of a JSON field value relative to an
+ * expected type hint, and determines whether a numeric value overflows an
+ * assumed narrower type.
+ *
+ * <h3>Why in the deserializer, not in DDL</h3>
+ * Debezium embeds type information in the schema history topic, not in each
+ * data event.  The stream processor does not consume the schema history topic.
+ * This class therefore operates on the runtime JSON node shape:
+ * <ul>
+ *   <li>Integer node (fits in int) → compatible with INT columns</li>
+ *   <li>Integer node (overflows int) → indicates WIDEN_TYPE (BIGINT appeared)</li>
+ *   <li>Integer node where a string was expected → INCOMPATIBLE_TYPE</li>
+ * </ul>
+ *
+ * <h3>Widening rules</h3>
+ * <pre>
+ *   INT    → BIGINT   : value.longValue() &gt; Integer.MAX_VALUE  → WIDEN_TYPE (BACKWARD)
+ *   FLOAT  → DOUBLE   : always safe; double precision is a superset
+ *   TINYINT→ SMALLINT : value fits; always safe
+ * </pre>
+ *
+ * <h3>Narrowing / incompatible rules</h3>
+ * <pre>
+ *   STRING → numeric  : INCOMPATIBLE_TYPE  (BREAKING)
+ *   numeric→ STRING   : INCOMPATIBLE_TYPE  (BREAKING)
+ *   BIGINT → INT with overflow : NARROW_TYPE (BREAKING)
+ * </pre>
+ */
+public final class TypeCompatibilityChecker {
+
+    private TypeCompatibilityChecker() {}
+
+    /**
+     * Examines {@code node} against the {@code expectedKind} for the given
+     * {@code column} and returns a {@link SchemaChange} when a type mismatch
+     * or widening is detected.
+     *
+     * @param column       column name (for diagnostics)
+     * @param node         JSON node containing the current value
+     * @param expectedKind one of "int", "long", "float", "double", "string"
+     * @return a {@link SchemaChange} if a type deviation is detected, or {@code null}
+     *         if the value is compatible with the expected kind
+     */
+    public static SchemaChange check(String column, JsonNode node, String expectedKind) {
+        if (node == null || node.isNull() || node.isMissingNode()) {
+            return null; // absent/null — handled as ADD_COLUMN or DROP_COLUMN elsewhere
+        }
+
+        return switch (expectedKind.toLowerCase()) {
+            case "int"    -> checkInt(column, node);
+            case "long"   -> checkLong(column, node);
+            case "float"  -> checkFloat(column, node);
+            case "double" -> checkDouble(column, node);
+            case "string" -> checkString(column, node);
+            default       -> null;
+        };
+    }
+
+    /**
+     * Returns {@code true} if moving from {@code oldKind} to {@code newKind}
+     * is a safe widening (BACKWARD compatible).
+     */
+    public static boolean isWidening(String oldKind, String newKind) {
+        return switch (oldKind.toLowerCase()) {
+            case "tinyint"  -> isOneOf(newKind, "smallint", "int", "long", "bigint", "float", "double");
+            case "smallint" -> isOneOf(newKind, "int", "long", "bigint", "float", "double");
+            case "int"      -> isOneOf(newKind, "long", "bigint", "float", "double");
+            case "long", "bigint" -> isOneOf(newKind, "double");
+            case "float"    -> isOneOf(newKind, "double");
+            default         -> false;
+        };
+    }
+
+    // ── Per-kind checks ──────────────────────────────────────────────────────
+
+    private static SchemaChange checkInt(String column, JsonNode node) {
+        if (node.isNumber()) {
+            long v = node.longValue();
+            if (v > Integer.MAX_VALUE || v < Integer.MIN_VALUE) {
+                return new SchemaChange(column, "int", "long/bigint", ChangeType.WIDEN_TYPE);
+            }
+            return null; // fits in int — fine
+        }
+        if (node.isTextual()) {
+            return new SchemaChange(column, "int", "string", ChangeType.INCOMPATIBLE_TYPE);
+        }
+        return null;
+    }
+
+    private static SchemaChange checkLong(String column, JsonNode node) {
+        if (node.isNumber()) {
+            return null; // all numeric values fit in long
+        }
+        if (node.isTextual()) {
+            return new SchemaChange(column, "long", "string", ChangeType.INCOMPATIBLE_TYPE);
+        }
+        return null;
+    }
+
+    private static SchemaChange checkFloat(String column, JsonNode node) {
+        if (node.isFloatingPointNumber()) {
+            return null; // fine
+        }
+        if (node.isIntegralNumber()) {
+            return null; // integral widened to float — safe
+        }
+        if (node.isTextual()) {
+            return new SchemaChange(column, "float", "string", ChangeType.INCOMPATIBLE_TYPE);
+        }
+        return null;
+    }
+
+    private static SchemaChange checkDouble(String column, JsonNode node) {
+        if (node.isNumber()) {
+            return null; // all numeric values fit in double
+        }
+        if (node.isTextual()) {
+            return new SchemaChange(column, "double", "string", ChangeType.INCOMPATIBLE_TYPE);
+        }
+        return null;
+    }
+
+    private static SchemaChange checkString(String column, JsonNode node) {
+        if (node.isTextual()) {
+            return null; // fine
+        }
+        if (node.isNumber()) {
+            return new SchemaChange(column, "string", "numeric", ChangeType.INCOMPATIBLE_TYPE);
+        }
+        return null;
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static boolean isOneOf(String value, String... options) {
+        String v = value.toLowerCase();
+        for (String o : options) {
+            if (v.equals(o)) return true;
+        }
+        return false;
+    }
+}

--- a/stream-processor/src/test/java/ai/streamforge/processor/SchemaEvolutionFilterTest.java
+++ b/stream-processor/src/test/java/ai/streamforge/processor/SchemaEvolutionFilterTest.java
@@ -1,0 +1,178 @@
+package ai.streamforge.processor;
+
+import ai.streamforge.processor.deserialization.SchemaEvolutionFilter;
+import ai.streamforge.processor.model.CdcEvent;
+import ai.streamforge.processor.model.DeadLetterEvent;
+import ai.streamforge.processor.model.SchemaVersion;
+import ai.streamforge.processor.schema.ChangeType;
+import ai.streamforge.processor.schema.CompatibilityLevel;
+import ai.streamforge.processor.schema.SchemaChange;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests {@link SchemaEvolutionFilter#classify(CdcEvent)} routing logic without
+ * a Flink runtime harness, following the same style as {@link InsertFilterWithMetricsTest}.
+ */
+class SchemaEvolutionFilterTest {
+
+    // ── Pass-through cases ────────────────────────────────────────────────────
+
+    @Test
+    void validInsert_passesThrough() {
+        assertNull(SchemaEvolutionFilter.classify(insertWithUser("u1")));
+    }
+
+    @Test
+    void updateOp_passesThroughEvenWithoutUserId() {
+        CdcEvent event = new CdcEvent();
+        event.op   = "u";
+        event.tsMs = 1700000000000L;
+        event.after = new CdcEvent.UserEventRow(); // userId == null
+        event.schemaVersion = SchemaVersion.V1;
+        assertNull(SchemaEvolutionFilter.classify(event));
+    }
+
+    @Test
+    void deleteOp_passesThrough() {
+        CdcEvent event = new CdcEvent();
+        event.op   = "d";
+        event.tsMs = 1700000000000L;
+        event.after = null;
+        event.schemaVersion = SchemaVersion.UNKNOWN;
+        assertNull(SchemaEvolutionFilter.classify(event));
+    }
+
+    @Test
+    void wideningChange_backwardCompatible_passesThrough() {
+        CdcEvent event = insertWithUser("u1");
+        event.detectedChanges.add(
+                new SchemaChange("created_at", "int", "long/bigint", ChangeType.WIDEN_TYPE));
+        assertNull(SchemaEvolutionFilter.classify(event),
+                "WIDEN_TYPE is BACKWARD compatible — should not route to DLQ");
+    }
+
+    @Test
+    void addColumnChange_fullCompatible_passesThrough() {
+        CdcEvent event = insertWithUser("u1");
+        event.detectedChanges.add(
+                new SchemaChange("session_id", null, "string", ChangeType.ADD_COLUMN));
+        assertNull(SchemaEvolutionFilter.classify(event));
+    }
+
+    // ── DLQ routing cases ─────────────────────────────────────────────────────
+
+    @Test
+    void insertMissingUserId_routedToDlq() {
+        CdcEvent event = new CdcEvent();
+        event.op   = "c";
+        event.tsMs = 1700000000000L;
+        event.after = new CdcEvent.UserEventRow(); // userId == null
+        event.schemaVersion = SchemaVersion.UNKNOWN;
+
+        DeadLetterEvent dlq = SchemaEvolutionFilter.classify(event);
+
+        assertNotNull(dlq);
+        assertEquals(ChangeType.DROP_COLUMN, dlq.changeType);
+        assertEquals(CompatibilityLevel.BREAKING, dlq.compatibilityLevel);
+        assertEquals("user_id", dlq.affectedColumn);
+    }
+
+    @Test
+    void snapshotReadMissingUserId_routedToDlq() {
+        CdcEvent event = new CdcEvent();
+        event.op   = "r";
+        event.tsMs = 1700000000000L;
+        event.after = new CdcEvent.UserEventRow();
+        event.schemaVersion = SchemaVersion.V1;
+
+        DeadLetterEvent dlq = SchemaEvolutionFilter.classify(event);
+
+        assertNotNull(dlq);
+        assertEquals(ChangeType.DROP_COLUMN, dlq.changeType);
+    }
+
+    @Test
+    void incompatibleTypeChange_routedToDlq() {
+        CdcEvent event = insertWithUser("u1");
+        event.detectedChanges.add(
+                new SchemaChange("created_at", "int", "string", ChangeType.INCOMPATIBLE_TYPE));
+
+        DeadLetterEvent dlq = SchemaEvolutionFilter.classify(event);
+
+        assertNotNull(dlq);
+        assertEquals(ChangeType.INCOMPATIBLE_TYPE, dlq.changeType);
+        assertEquals("created_at", dlq.affectedColumn);
+        assertEquals(CompatibilityLevel.BREAKING, dlq.compatibilityLevel);
+        assertTrue(dlq.errorMessage.contains("BREAKING"));
+        assertTrue(dlq.errorMessage.contains("created_at"));
+    }
+
+    @Test
+    void narrowTypeChange_routedToDlq() {
+        CdcEvent event = insertWithUser("u1");
+        event.detectedChanges.add(
+                new SchemaChange("amount", "long", "int", ChangeType.NARROW_TYPE));
+
+        DeadLetterEvent dlq = SchemaEvolutionFilter.classify(event);
+
+        assertNotNull(dlq);
+        assertEquals(ChangeType.NARROW_TYPE, dlq.changeType);
+        assertEquals("amount", dlq.affectedColumn);
+    }
+
+    @Test
+    void dropRequiredColumn_routedToDlq() {
+        CdcEvent event = insertWithUser("u1");
+        event.detectedChanges.add(
+                new SchemaChange("user_id", "string", null, ChangeType.DROP_COLUMN));
+
+        DeadLetterEvent dlq = SchemaEvolutionFilter.classify(event);
+
+        assertNotNull(dlq);
+        assertEquals(ChangeType.DROP_COLUMN, dlq.changeType);
+    }
+
+    @Test
+    void dlqEntryCarriesSchemaVersion() {
+        CdcEvent event = new CdcEvent();
+        event.op   = "c";
+        event.tsMs = 1700000000000L;
+        event.after = new CdcEvent.UserEventRow();
+        event.schemaVersion = SchemaVersion.V2;
+
+        DeadLetterEvent dlq = SchemaEvolutionFilter.classify(event);
+
+        assertNotNull(dlq);
+        assertEquals(SchemaVersion.V2, dlq.schemaVersion);
+    }
+
+    @Test
+    void firstBreakingChangeWins_whenMultipleDetected() {
+        CdcEvent event = insertWithUser("u1");
+        event.detectedChanges.add(
+                new SchemaChange("col_a", "int", "string", ChangeType.INCOMPATIBLE_TYPE));
+        event.detectedChanges.add(
+                new SchemaChange("col_b", "long", "int", ChangeType.NARROW_TYPE));
+
+        DeadLetterEvent dlq = SchemaEvolutionFilter.classify(event);
+
+        assertNotNull(dlq);
+        assertEquals("col_a", dlq.affectedColumn, "first BREAKING change takes priority");
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static CdcEvent insertWithUser(String userId) {
+        CdcEvent event = new CdcEvent();
+        event.op   = "c";
+        event.tsMs = 1700000000000L;
+        event.after = new CdcEvent.UserEventRow();
+        event.after.userId    = userId;
+        event.after.eventType = "click";
+        event.after.createdAt = 1700000000000L;
+        event.schemaVersion   = SchemaVersion.V1;
+        return event;
+    }
+}

--- a/stream-processor/src/test/java/ai/streamforge/processor/SchemaEvolutionHandlerTest.java
+++ b/stream-processor/src/test/java/ai/streamforge/processor/SchemaEvolutionHandlerTest.java
@@ -3,8 +3,11 @@ package ai.streamforge.processor;
 import ai.streamforge.processor.deserialization.SchemaEvolutionHandler;
 import ai.streamforge.processor.model.CdcEvent;
 import ai.streamforge.processor.model.SchemaVersion;
+import ai.streamforge.processor.schema.ChangeType;
+import ai.streamforge.processor.schema.ColumnAliasRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -12,140 +15,282 @@ import static org.junit.jupiter.api.Assertions.*;
 class SchemaEvolutionHandlerTest {
 
     private ObjectMapper mapper;
+    private ColumnAliasRegistry aliases;
 
     @BeforeEach
     void setUp() {
-        mapper = new ObjectMapper();
+        mapper  = new ObjectMapper();
+        aliases = ColumnAliasRegistry.builtinsOnly();
     }
 
-    // ── Schema version detection ─────────────────────────────────────────────
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Column ADD — FULL compatibility
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Nested
+    class AddColumn {
 
-    @Test
-    void detectsV1SchemaFromUserIdField() throws Exception {
-        String json = """
-                {"op":"c","ts_ms":1700000000000,
-                 "after":{"user_id":"u1","event_type":"click","created_at":1700000000000}}
-                """;
-        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
-        assertEquals(SchemaVersion.V1, event.schemaVersion);
+        @Test
+        void v1EventMissingSessionId_nullFilled() throws Exception {
+            String json = event("c", after("user_id", "u1", "event_type", "click",
+                    "created_at", 1700000000000L));
+            CdcEvent e = parse(json);
+            assertEquals(SchemaVersion.V1, e.schemaVersion);
+            assertNull(e.after.sessionId);
+            assertNull(e.after.ipAddress);
+            assertTrue(e.detectedChanges.isEmpty(), "no changes for missing optional field");
+        }
+
+        @Test
+        void v2EventCarriesNewColumns() throws Exception {
+            String json = event("c", afterV2("u1", "click", 1700000000000L, "sess-1", "10.0.0.1"));
+            CdcEvent e = parse(json);
+            assertEquals(SchemaVersion.V2, e.schemaVersion);
+            assertEquals("sess-1",   e.after.sessionId);
+            assertEquals("10.0.0.1", e.after.ipAddress);
+            assertTrue(e.detectedChanges.isEmpty());
+        }
+
+        @Test
+        void v3EventCarriesMetadataBlob() throws Exception {
+            String json = """
+                    {"op":"c","ts_ms":1700000000000,
+                     "after":{"user_id":"u1","event_type":"click","created_at":1700000000000,
+                               "session_id":"s1","ip_address":"1.2.3.4",
+                               "metadata":"{\\"source\\":\\"web\\"}"}}
+                    """;
+            CdcEvent e = parse(json);
+            assertEquals(SchemaVersion.V3, e.schemaVersion);
+            assertNotNull(e.after.metadata);
+            assertTrue(e.after.metadata.contains("web"));
+        }
     }
 
-    @Test
-    void detectsV2SchemaWhenSessionIdPresent() throws Exception {
-        String json = """
-                {"op":"c","ts_ms":1700000000000,
-                 "after":{"user_id":"u1","event_type":"click","created_at":1700000000000,
-                           "session_id":"sess-abc","ip_address":"192.168.1.1"}}
-                """;
-        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
-        assertEquals(SchemaVersion.V2, event.schemaVersion);
-        assertEquals("sess-abc", event.after.sessionId);
-        assertEquals("192.168.1.1", event.after.ipAddress);
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Column DROP
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Nested
+    class DropColumn {
+
+        @Test
+        void droppingOptionalEventType_nullFilledNoChange() throws Exception {
+            String json = event("c", afterSimple("user_id", "u1"));
+            CdcEvent e = parse(json);
+            assertNull(e.after.eventType);
+            // Only user_id is required; no drop change expected for optional field
+            assertTrue(e.detectedChanges.isEmpty());
+        }
+
+        @Test
+        void droppingRequiredUserId_detectsDropChange() throws Exception {
+            String json = event("c",
+                    "{\"event_type\":\"click\",\"created_at\":1700000000000}");
+            CdcEvent e = parse(json);
+            assertNull(e.after.userId);
+            assertEquals(1, e.detectedChanges.size());
+            assertEquals(ChangeType.DROP_COLUMN, e.detectedChanges.get(0).changeType);
+            assertEquals("user_id", e.detectedChanges.get(0).column);
+        }
+
+        @Test
+        void deleteOp_afterIsNull_noDropDetected() throws Exception {
+            String json = "{\"op\":\"d\",\"ts_ms\":1700000000000,\"after\":null}";
+            CdcEvent e = parse(json);
+            assertEquals(SchemaVersion.UNKNOWN, e.schemaVersion);
+            assertNull(e.after);
+            assertTrue(e.detectedChanges.isEmpty());
+        }
     }
 
-    @Test
-    void detectsUnknownSchemaWhenAfterIsNull() throws Exception {
-        String json = """
-                {"op":"d","ts_ms":1700000000000,"after":null}
-                """;
-        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
-        assertEquals(SchemaVersion.UNKNOWN, event.schemaVersion);
-        assertNull(event.after);
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Column RENAME — via alias registry
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Nested
+    class RenameColumn {
+
+        @Test
+        void builtinAlias_uid_resolvesToUserId() throws Exception {
+            String json = event("c",
+                    "{\"uid\":\"user-renamed\",\"event_type\":\"view\",\"created_at\":1700000000000}");
+            CdcEvent e = parse(json);
+            assertEquals("user-renamed", e.after.userId);
+            assertTrue(e.detectedChanges.isEmpty());
+        }
+
+        @Test
+        void builtinAlias_type_resolvesToEventType() throws Exception {
+            String json = event("c",
+                    "{\"user_id\":\"u1\",\"type\":\"purchase\",\"created_at\":1700000000000}");
+            CdcEvent e = parse(json);
+            assertEquals("purchase", e.after.eventType);
+        }
+
+        @Test
+        void builtinAlias_ts_resolvesToCreatedAt() throws Exception {
+            String json = event("c",
+                    "{\"user_id\":\"u1\",\"event_type\":\"click\",\"ts\":1699999999000}");
+            CdcEvent e = parse(json);
+            assertEquals(1699999999000L, e.after.createdAt);
+        }
+
+        @Test
+        void canonicalFieldTakesPriorityOverAlias() throws Exception {
+            String json = event("c",
+                    "{\"user_id\":\"canonical\",\"uid\":\"alias\","
+                    + "\"event_type\":\"click\",\"created_at\":1700000000000}");
+            CdcEvent e = parse(json);
+            assertEquals("canonical", e.after.userId);
+        }
+
+        @Test
+        void runtimeAlias_customerIdResolvesToUserId() throws Exception {
+            ColumnAliasRegistry custom = ColumnAliasRegistry.builtinsOnly();
+            custom.register("customer_id", "user_id");
+
+            String json = event("c",
+                    "{\"customer_id\":\"cust-99\",\"event_type\":\"click\",\"created_at\":1700000000000}");
+            CdcEvent e = SchemaEvolutionHandler.handle(json.getBytes(), mapper, custom);
+            assertEquals("cust-99", e.after.userId);
+            assertTrue(e.detectedChanges.isEmpty(), "alias registration makes rename transparent");
+        }
+
+        @Test
+        void unregisteredRename_userId_absent_detectsDrop() throws Exception {
+            // Column was renamed to 'account_id' but no alias registered
+            String json = event("c",
+                    "{\"account_id\":\"acc-1\",\"event_type\":\"click\",\"created_at\":1700000000000}");
+            CdcEvent e = parse(json);
+            assertNull(e.after.userId);
+            assertEquals(1, e.detectedChanges.size());
+            assertEquals(ChangeType.DROP_COLUMN, e.detectedChanges.get(0).changeType);
+        }
     }
 
-    // ── Field alias normalization ────────────────────────────────────────────
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Type WIDENING — BACKWARD compatible
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Nested
+    class TypeWidening {
 
-    @Test
-    void normalizesUidAliasToUserId() throws Exception {
-        String json = """
-                {"op":"c","ts_ms":1700000000000,
-                 "after":{"uid":"user-renamed","event_type":"view","created_at":1700000000000}}
-                """;
-        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
-        assertEquals("user-renamed", event.after.userId);
+        @Test
+        void createdAtFitsInInt_noWideningDetected() throws Exception {
+            String json = event("c",
+                    "{\"user_id\":\"u1\",\"event_type\":\"click\",\"created_at\":1000000}");
+            CdcEvent e = parse(json);
+            assertTrue(e.detectedChanges.isEmpty());
+            assertEquals(1_000_000L, e.after.createdAt);
+        }
+
+        @Test
+        void createdAtOverflowsInt_detectsWidening() throws Exception {
+            long bigTs = (long) Integer.MAX_VALUE + 999;
+            String json = event("c",
+                    "{\"user_id\":\"u1\",\"event_type\":\"click\",\"created_at\":" + bigTs + "}");
+            CdcEvent e = parse(json);
+            assertEquals(1, e.detectedChanges.size());
+            assertEquals(ChangeType.WIDEN_TYPE, e.detectedChanges.get(0).changeType);
+            assertEquals("created_at", e.detectedChanges.get(0).column);
+            assertEquals(bigTs, e.after.createdAt, "value still correctly parsed");
+            assertEquals(SchemaVersion.V3, e.schemaVersion, "overflow triggers V3 detection");
+        }
+
+        @Test
+        void createdAtWidenedAlsoViaAlias_ts() throws Exception {
+            long bigTs = (long) Integer.MAX_VALUE + 1;
+            String json = event("c",
+                    "{\"user_id\":\"u1\",\"event_type\":\"click\",\"ts\":" + bigTs + "}");
+            CdcEvent e = parse(json);
+            assertEquals(1, e.detectedChanges.size());
+            assertEquals(ChangeType.WIDEN_TYPE, e.detectedChanges.get(0).changeType);
+            assertEquals(bigTs, e.after.createdAt);
+        }
     }
 
-    @Test
-    void normalizesTypeAliasToEventType() throws Exception {
-        String json = """
-                {"op":"c","ts_ms":1700000000000,
-                 "after":{"user_id":"u1","type":"purchase","created_at":1700000000000}}
-                """;
-        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
-        assertEquals("purchase", event.after.eventType);
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Incompatible type change — BREAKING
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Nested
+    class IncompatibleType {
+
+        @Test
+        void createdAtIsString_detectsIncompatibleType() throws Exception {
+            String json = event("c",
+                    "{\"user_id\":\"u1\",\"event_type\":\"click\",\"created_at\":\"2024-01-01\"}");
+            CdcEvent e = parse(json);
+            assertEquals(1, e.detectedChanges.size());
+            assertEquals(ChangeType.INCOMPATIBLE_TYPE, e.detectedChanges.get(0).changeType);
+        }
     }
 
-    @Test
-    void normalizesTsAliasToCreatedAt() throws Exception {
-        String json = """
-                {"op":"c","ts_ms":1700000000000,
-                 "after":{"user_id":"u1","event_type":"click","ts":1699999999000}}
-                """;
-        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
-        assertEquals(1699999999000L, event.after.createdAt);
+    // ═══════════════════════════════════════════════════════════════════════════
+    // Envelope / misc
+    // ═══════════════════════════════════════════════════════════════════════════
+    @Nested
+    class Envelope {
+
+        @Test
+        void parsesOpAndTsMs() throws Exception {
+            String json = event("u", after("user_id", "u2", "event_type", "update",
+                    "created_at", 1700001234000L));
+            CdcEvent e = parse(json);
+            assertEquals("u", e.op);
+        }
+
+        @Test
+        void ignoresUnknownEnvelopeFields() throws Exception {
+            String json = """
+                    {"op":"c","ts_ms":1700000000000,
+                     "source":{"connector":"mysql"},"transaction":null,
+                     "after":{"user_id":"u1","event_type":"click","created_at":1700000000000}}
+                    """;
+            CdcEvent e = parse(json);
+            assertEquals("u1", e.after.userId);
+        }
+
+        @Test
+        void toleratesMissingOptionalFields() throws Exception {
+            String json = event("c", afterSimple("user_id", "u1"));
+            CdcEvent e = parse(json);
+            assertNull(e.after.eventType);
+            assertNull(e.after.createdAt);
+            assertNull(e.after.sessionId);
+        }
+
+        @Test
+        void afterIsNull_unknownVersion() throws Exception {
+            String json = "{\"op\":\"d\",\"ts_ms\":1700000000000,\"after\":null}";
+            CdcEvent e = parse(json);
+            assertEquals(SchemaVersion.UNKNOWN, e.schemaVersion);
+        }
     }
 
-    @Test
-    void canonicalFieldTakesPriorityOverAlias() throws Exception {
-        String json = """
-                {"op":"c","ts_ms":1700000000000,
-                 "after":{"user_id":"canonical","uid":"alias","event_type":"click","created_at":1700000000000}}
-                """;
-        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
-        assertEquals("canonical", event.after.userId);
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private CdcEvent parse(String json) throws Exception {
+        return SchemaEvolutionHandler.handle(json.getBytes(), mapper, aliases);
     }
 
-    // ── Missing / nullable fields ────────────────────────────────────────────
-
-    @Test
-    void toleratesMissingOptionalFields() throws Exception {
-        String json = """
-                {"op":"c","ts_ms":1700000000000,
-                 "after":{"user_id":"u1"}}
-                """;
-        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
-        assertEquals("u1", event.after.userId);
-        assertNull(event.after.eventType);
-        assertNull(event.after.createdAt);
-        assertNull(event.after.sessionId);
-        assertNull(event.after.ipAddress);
+    private static String event(String op, String afterJson) {
+        return "{\"op\":\"" + op + "\",\"ts_ms\":1700000000000,\"after\":" + afterJson + "}";
     }
 
-    @Test
-    void toleratesNullFieldValues() throws Exception {
-        String json = """
-                {"op":"c","ts_ms":1700000000000,
-                 "after":{"user_id":"u1","event_type":null,"created_at":null}}
-                """;
-        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
-        assertEquals("u1", event.after.userId);
-        assertNull(event.after.eventType);
-        assertNull(event.after.createdAt);
+    private static String after(String k1, Object v1, String k2, Object v2,
+                                String k3, Object v3) {
+        return "{\"" + k1 + "\":" + quote(v1) + ",\""
+                + k2 + "\":" + quote(v2) + ",\""
+                + k3 + "\":" + quote(v3) + "}";
     }
 
-    // ── Envelope fields ──────────────────────────────────────────────────────
-
-    @Test
-    void parsesOpAndTsMs() throws Exception {
-        String json = """
-                {"op":"u","ts_ms":1700001234567,
-                 "after":{"user_id":"u2","event_type":"update","created_at":1700001234000}}
-                """;
-        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
-        assertEquals("u", event.op);
-        assertEquals(1700001234567L, event.tsMs);
+    private static String afterV2(String userId, String type, long ts, String session, String ip) {
+        return "{\"user_id\":\"" + userId + "\",\"event_type\":\"" + type + "\","
+                + "\"created_at\":" + ts + ",\"session_id\":\"" + session + "\","
+                + "\"ip_address\":\"" + ip + "\"}";
     }
 
-    @Test
-    void ignoresUnknownEnvelopeFields() throws Exception {
-        String json = """
-                {"op":"c","ts_ms":1700000000000,
-                 "source":{"connector":"mysql","table":"user_events"},
-                 "transaction":null,
-                 "after":{"user_id":"u1","event_type":"click","created_at":1700000000000}}
-                """;
-        CdcEvent event = SchemaEvolutionHandler.handle(json.getBytes(), mapper);
-        assertEquals("c", event.op);
-        assertEquals("u1", event.after.userId);
+    private static String afterSimple(String k, Object v) {
+        return "{\"" + k + "\":" + quote(v) + "}";
+    }
+
+    private static String quote(Object v) {
+        return (v instanceof String) ? "\"" + v + "\"" : String.valueOf(v);
     }
 }

--- a/stream-processor/src/test/java/ai/streamforge/processor/schema/ColumnAliasRegistryTest.java
+++ b/stream-processor/src/test/java/ai/streamforge/processor/schema/ColumnAliasRegistryTest.java
@@ -1,0 +1,99 @@
+package ai.streamforge.processor.schema;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ColumnAliasRegistryTest {
+
+    // ── Built-ins ────────────────────────────────────────────────────────────
+
+    @Test
+    void builtinsResolveUidToUserId() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.builtinsOnly();
+        assertEquals("user_id", r.resolve("uid"));
+    }
+
+    @Test
+    void builtinsResolveTypeToEventType() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.builtinsOnly();
+        assertEquals("event_type", r.resolve("type"));
+    }
+
+    @Test
+    void builtinsResolveTsToCreatedAt() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.builtinsOnly();
+        assertEquals("created_at", r.resolve("ts"));
+    }
+
+    @Test
+    void canonicalFieldReturnsItself() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.builtinsOnly();
+        assertEquals("user_id", r.resolve("user_id"));
+        assertEquals("event_type", r.resolve("event_type"));
+        assertEquals("created_at", r.resolve("created_at"));
+    }
+
+    @Test
+    void unknownFieldReturnsItself() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.builtinsOnly();
+        assertEquals("some_random_column", r.resolve("some_random_column"));
+    }
+
+    // ── Registration ─────────────────────────────────────────────────────────
+
+    @Test
+    void registerCustomAlias() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.empty();
+        r.register("customer_id", "user_id");
+        assertEquals("user_id", r.resolve("customer_id"));
+    }
+
+    @Test
+    void registerRejectsBlankInputs() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.empty();
+        assertThrows(IllegalArgumentException.class, () -> r.register("", "user_id"));
+        assertThrows(IllegalArgumentException.class, () -> r.register("uid", ""));
+        assertThrows(IllegalArgumentException.class, () -> r.register(null, "user_id"));
+    }
+
+    @Test
+    void isAliasReturnsTrueForRegisteredAlias() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.builtinsOnly();
+        assertTrue(r.isAlias("uid"));
+        assertFalse(r.isAlias("user_id"));
+    }
+
+    // ── Env loading ──────────────────────────────────────────────────────────
+
+    @Test
+    void loadFromEnvParsesValidSpec() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.empty();
+        r.loadFromEnv("customer_id=user_id,kind=event_type");
+        assertEquals("user_id",    r.resolve("customer_id"));
+        assertEquals("event_type", r.resolve("kind"));
+    }
+
+    @Test
+    void loadFromEnvSkipsMalformedEntries() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.empty();
+        r.loadFromEnv("customer_id=user_id,MALFORMED,=empty_key");
+        assertEquals("user_id", r.resolve("customer_id"));
+        assertEquals("MALFORMED", r.resolve("MALFORMED")); // unchanged
+    }
+
+    @Test
+    void loadFromEnvHandlesNullAndBlank() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.empty();
+        assertDoesNotThrow(() -> r.loadFromEnv(null));
+        assertDoesNotThrow(() -> r.loadFromEnv(""));
+        assertDoesNotThrow(() -> r.loadFromEnv("   "));
+    }
+
+    @Test
+    void allAliasesIsUnmodifiable() {
+        ColumnAliasRegistry r = ColumnAliasRegistry.builtinsOnly();
+        assertThrows(UnsupportedOperationException.class,
+                () -> r.allAliases().put("bad", "injection"));
+    }
+}

--- a/stream-processor/src/test/java/ai/streamforge/processor/schema/TypeCompatibilityCheckerTest.java
+++ b/stream-processor/src/test/java/ai/streamforge/processor/schema/TypeCompatibilityCheckerTest.java
@@ -1,0 +1,121 @@
+package ai.streamforge.processor.schema;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.IntNode;
+import com.fasterxml.jackson.databind.node.LongNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TypeCompatibilityCheckerTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    // ── INT checks ───────────────────────────────────────────────────────────
+
+    @Test
+    void intValueFitsInInt_noChange() {
+        assertNull(TypeCompatibilityChecker.check("col", IntNode.valueOf(42), "int"));
+    }
+
+    @Test
+    void intValueOverflowsInt_detectsWidening() {
+        long bigValue = (long) Integer.MAX_VALUE + 1;
+        SchemaChange change = TypeCompatibilityChecker.check("ts", LongNode.valueOf(bigValue), "int");
+        assertNotNull(change);
+        assertEquals(ChangeType.WIDEN_TYPE, change.changeType);
+        assertEquals("ts", change.column);
+        assertEquals(CompatibilityLevel.BACKWARD, change.effectiveCompatibility);
+    }
+
+    @Test
+    void stringWhereIntExpected_detectsIncompatible() {
+        SchemaChange change = TypeCompatibilityChecker.check("ts", TextNode.valueOf("2024-01-01"), "int");
+        assertNotNull(change);
+        assertEquals(ChangeType.INCOMPATIBLE_TYPE, change.changeType);
+        assertEquals(CompatibilityLevel.BREAKING, change.effectiveCompatibility);
+    }
+
+    // ── LONG checks ──────────────────────────────────────────────────────────
+
+    @Test
+    void anyNumericFitsInLong_noChange() {
+        assertNull(TypeCompatibilityChecker.check("col", LongNode.valueOf(Long.MAX_VALUE), "long"));
+    }
+
+    @Test
+    void stringWhereIntLongExpected_detectsIncompatible() {
+        SchemaChange change = TypeCompatibilityChecker.check("col", TextNode.valueOf("abc"), "long");
+        assertNotNull(change);
+        assertEquals(ChangeType.INCOMPATIBLE_TYPE, change.changeType);
+    }
+
+    // ── STRING checks ────────────────────────────────────────────────────────
+
+    @Test
+    void textNodeWhereStringExpected_noChange() {
+        assertNull(TypeCompatibilityChecker.check("name", TextNode.valueOf("Alice"), "string"));
+    }
+
+    @Test
+    void numericWhereStringExpected_detectsIncompatible() {
+        SchemaChange change = TypeCompatibilityChecker.check("name", IntNode.valueOf(123), "string");
+        assertNotNull(change);
+        assertEquals(ChangeType.INCOMPATIBLE_TYPE, change.changeType);
+    }
+
+    // ── FLOAT / DOUBLE ───────────────────────────────────────────────────────
+
+    @Test
+    void floatNode_noChangeForFloatExpected() throws Exception {
+        var node = mapper.readTree("3.14");
+        assertNull(TypeCompatibilityChecker.check("col", node, "float"));
+    }
+
+    @Test
+    void doubleNode_noChangeForDoubleExpected() throws Exception {
+        var node = mapper.readTree("3.141592653589793");
+        assertNull(TypeCompatibilityChecker.check("col", node, "double"));
+    }
+
+    // ── Null / missing ───────────────────────────────────────────────────────
+
+    @Test
+    void nullNode_returnsNull() throws Exception {
+        var node = mapper.readTree("null");
+        assertNull(TypeCompatibilityChecker.check("col", node, "int"));
+    }
+
+    @Test
+    void nullReference_returnsNull() {
+        assertNull(TypeCompatibilityChecker.check("col", null, "int"));
+    }
+
+    // ── isWidening ───────────────────────────────────────────────────────────
+
+    @Test
+    void intToLong_isWidening() {
+        assertTrue(TypeCompatibilityChecker.isWidening("int", "long"));
+    }
+
+    @Test
+    void intToDouble_isWidening() {
+        assertTrue(TypeCompatibilityChecker.isWidening("int", "double"));
+    }
+
+    @Test
+    void floatToDouble_isWidening() {
+        assertTrue(TypeCompatibilityChecker.isWidening("float", "double"));
+    }
+
+    @Test
+    void longToInt_isNotWidening() {
+        assertFalse(TypeCompatibilityChecker.isWidening("long", "int"));
+    }
+
+    @Test
+    void stringToInt_isNotWidening() {
+        assertFalse(TypeCompatibilityChecker.isWidening("string", "int"));
+    }
+}


### PR DESCRIPTION
Implements a four-category compatibility policy (add/drop/rename/type-widen) end-to-end through Kafka → Flink → sink, with typed dead-letter routing and a one-shot DlqReprocessingJob for incompatible changes.

New classes:
- schema/CompatibilityLevel — BACKWARD / FORWARD / FULL / BREAKING
- schema/ChangeType — ADD_COLUMN / DROP_COLUMN / RENAME_COLUMN / WIDEN_TYPE / NARROW_TYPE / INCOMPATIBLE_TYPE
- schema/SchemaChange — per-change metadata attached to CdcEvent.detectedChanges
- schema/ColumnAliasRegistry — runtime-configurable alias map (COLUMN_ALIASES env var); built-in uid→user_id, type→event_type, ts→created_at
- schema/TypeCompatibilityChecker — detects INT→BIGINT widening and string/numeric incompatibilities from JSON node shape
- reprocessing/DlqReprocessingJob — drains DLQ, re-deserializes with updated alias registry, re-injects valid events into source topic; unresolvable events go to secondary DLQ

Updated:
- SchemaEvolutionHandler — uses ColumnAliasRegistry for all field resolution; TypeCompatibilityChecker annotates type deviations; V3 schema version for BIGINT timestamps and metadata blob
- SchemaEvolutionFilter — classify() static method routes BREAKING changes to DLQ with full ChangeType/schemaVersion/affectedColumn metadata
- CdcEvent — adds detectedChanges list (transient) and metadata field (V3)
- DeadLetterEvent — adds changeType, schemaVersion, affectedColumn, compatibilityLevel
- SchemaVersion — adds V3

Docs:
- docs/SCHEMA_EVOLUTION.md — compatibility matrix, per-change-type handling, 4-case reprocessing runbook

Tests: ColumnAliasRegistryTest, TypeCompatibilityCheckerTest, SchemaEvolutionHandlerTest (expanded), SchemaEvolutionFilterTest