### PR TITLE
docs(tuning): document and expose tuning knobs for Flink, Kafka, MinI…

### DIFF
--- a/deploy/cdc-flink-minio-demo/feature-sink/feature_to_minio.py
+++ b/deploy/cdc-flink-minio-demo/feature-sink/feature_to_minio.py
@@ -1,3 +1,47 @@
+"""
+Kafka → MinIO feature sink.
+
+Tuning knobs (environment variables)
+-------------------------------------
+Kafka consumer:
+  KAFKA_BOOTSTRAP_SERVERS  — broker list, default kafka:9092
+  KAFKA_TOPIC              — source topic, default streamforge.features.user_event_counts
+  KAFKA_GROUP_ID           — consumer group, default streamforge-feature-minio-sink
+  KAFKA_FETCH_MAX_BYTES    — fetch.max.bytes per poll, default 52428800 (50 MB)
+                             Larger → fewer round-trips at the cost of memory.
+  KAFKA_MAX_POLL_RECORDS   — max.poll.records per poll, default 500
+                             Higher values increase throughput; lower values reduce
+                             end-to-end latency and rebalance pause time.
+
+Batching / flushing:
+  SINK_BATCH_SIZE          — number of records to buffer before a single PUT, default 1
+                             Batching amortises per-PUT latency but increases
+                             in-flight memory and worst-case delivery delay.
+  SINK_BATCH_TIMEOUT_S     — max seconds to hold a partial batch, default 5.0
+                             Lower → closer to record-level latency.
+                             Higher → better compression ratio and fewer S3 requests.
+
+MinIO / S3:
+  MINIO_ENDPOINT           — host:port, default minio:9000
+  MINIO_ACCESS_KEY         — default minioadmin
+  MINIO_SECRET_KEY         — default minioadmin
+  MINIO_BUCKET             — bucket name, default processed
+  MINIO_PREFIX             — object key prefix, default streamforge/features
+  MINIO_SECURE             — use HTTPS, default false
+  MINIO_PART_SIZE          — multipart part size in bytes, default 10485760 (10 MB)
+                             Must be ≥ 5 MB (MinIO/AWS minimum). Larger parts improve
+                             PUT throughput for big payloads at the cost of memory.
+                             Objects smaller than this are uploaded as a single PUT.
+
+Prefix sharding:
+  MINIO_SHARD_DEPTH        — number of date-hierarchy levels prepended to the key:
+                               0 → <prefix>/<timestamp>.json
+                               1 → <prefix>/2024/01/15/<timestamp>.json  (default)
+                               2 → <prefix>/2024/01/<timestamp>.json
+                             Sharding distributes load across MinIO/S3 key-space
+                             prefixes, which matters for high-throughput workloads
+                             where a flat prefix becomes a hot-spot.
+"""
 import json
 import os
 import time
@@ -18,40 +62,78 @@ def ensure_bucket(client: Minio, bucket: str) -> None:
         client.make_bucket(bucket)
 
 
-def build_object_key(prefix: str) -> str:
+def build_object_key(prefix: str, shard_depth: int) -> str:
     now = datetime.now(timezone.utc)
-    return f"{prefix}/{now.strftime('%Y/%m/%d/%H%M%S')}-{int(time.time() * 1000)}.json"
+    ts = int(time.time() * 1000)
+    if shard_depth >= 1:
+        date_path = now.strftime("%Y/%m/%d")
+        return f"{prefix}/{date_path}/{now.strftime('%H%M%S')}-{ts}.json"
+    return f"{prefix}/{now.strftime('%Y%m%d-%H%M%S')}-{ts}.json"
+
+
+def flush_batch(client: Minio, bucket: str, prefix: str,
+                shard_depth: int, part_size: int, records: list) -> None:
+    """Write a batch of records as a single JSON-lines object to MinIO."""
+    lines = "\n".join(json.dumps(r, separators=(",", ":")) for r in records) + "\n"
+    data = lines.encode("utf-8")
+    key = build_object_key(prefix, shard_depth)
+    client.put_object(
+        bucket_name=bucket,
+        object_name=key,
+        data=BytesIO(data),
+        length=len(data),
+        content_type="application/json",
+        part_size=part_size,
+    )
+    print(f"[SINK] Wrote {len(records)} record(s) ({len(data)} bytes) → minio://{bucket}/{key}")
 
 
 def main() -> None:
-    kafka_servers = env("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
-    kafka_topic = env("KAFKA_TOPIC", "streamforge.features.user_event_counts")
-    kafka_group = env("KAFKA_GROUP_ID", "streamforge-feature-minio-sink")
+    kafka_servers   = env("KAFKA_BOOTSTRAP_SERVERS", "kafka:9092")
+    kafka_topic     = env("KAFKA_TOPIC",             "streamforge.features.user_event_counts")
+    kafka_group     = env("KAFKA_GROUP_ID",          "streamforge-feature-minio-sink")
+    fetch_max_bytes = int(env("KAFKA_FETCH_MAX_BYTES",  "52428800"))
+    max_poll_records = int(env("KAFKA_MAX_POLL_RECORDS", "500"))
 
-    minio_endpoint = env("MINIO_ENDPOINT", "minio:9000")
-    minio_access_key = env("MINIO_ACCESS_KEY", "minioadmin")
-    minio_secret_key = env("MINIO_SECRET_KEY", "minioadmin")
-    minio_bucket = env("MINIO_BUCKET", "processed")
-    minio_prefix = env("MINIO_PREFIX", "streamforge/features")
+    minio_endpoint  = env("MINIO_ENDPOINT",   "minio:9000")
+    minio_access    = env("MINIO_ACCESS_KEY", "minioadmin")
+    minio_secret    = env("MINIO_SECRET_KEY", "minioadmin")
+    minio_bucket    = env("MINIO_BUCKET",     "processed")
+    minio_prefix    = env("MINIO_PREFIX",     "streamforge/features")
+    minio_secure    = env("MINIO_SECURE",     "false").lower() == "true"
+    part_size       = int(env("MINIO_PART_SIZE",   "10485760"))  # 10 MB
+    shard_depth     = int(env("MINIO_SHARD_DEPTH", "1"))
 
-    print(f"[SINK] Starting Kafka->MinIO sink topic={kafka_topic} endpoint={minio_endpoint}")
+    batch_size      = int(env("SINK_BATCH_SIZE",    "1"))
+    batch_timeout_s = float(env("SINK_BATCH_TIMEOUT_S", "5.0"))
+
+    print(
+        f"[SINK] Starting Kafka→MinIO sink  topic={kafka_topic}  endpoint={minio_endpoint}\n"
+        f"       batch_size={batch_size}  batch_timeout={batch_timeout_s}s  "
+        f"part_size={part_size // 1024 // 1024} MB  shard_depth={shard_depth}"
+    )
 
     consumer = KafkaConsumer(
         kafka_topic,
         bootstrap_servers=[kafka_servers],
         group_id=kafka_group,
         auto_offset_reset="earliest",
-        enable_auto_commit=True,
+        enable_auto_commit=False,  # commit only after successful PUT
+        fetch_max_bytes=fetch_max_bytes,
+        max_poll_records=max_poll_records,
         value_deserializer=lambda v: v.decode("utf-8"),
     )
 
     minio_client = Minio(
         endpoint=minio_endpoint,
-        access_key=minio_access_key,
-        secret_key=minio_secret_key,
-        secure=False,
+        access_key=minio_access,
+        secret_key=minio_secret,
+        secure=minio_secure,
     )
     ensure_bucket(minio_client, minio_bucket)
+
+    batch: list = []
+    batch_start = time.monotonic()
 
     for msg in consumer:
         raw_value = msg.value
@@ -61,18 +143,15 @@ def main() -> None:
             payload = {"raw": raw_value}
 
         payload["sink_received_at"] = datetime.now(timezone.utc).isoformat()
-        data = (json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8")
-        key = build_object_key(minio_prefix)
+        batch.append(payload)
 
-        minio_client.put_object(
-            bucket_name=minio_bucket,
-            object_name=key,
-            data=BytesIO(data),
-            length=len(data),
-            content_type="application/json",
-        )
-
-        print(f"[SINK] Wrote feature event to minio://{minio_bucket}/{key}")
+        elapsed = time.monotonic() - batch_start
+        if len(batch) >= batch_size or elapsed >= batch_timeout_s:
+            flush_batch(minio_client, minio_bucket, minio_prefix,
+                        shard_depth, part_size, batch)
+            consumer.commit()
+            batch = []
+            batch_start = time.monotonic()
 
 
 if __name__ == "__main__":

--- a/docs/TUNING.md
+++ b/docs/TUNING.md
@@ -1,0 +1,457 @@
+# StreamForge AI — Performance Tuning Guide
+
+This document describes every exposed tuning knob for the four subsystems in the
+StreamForge CDC pipeline:
+
+```
+MySQL → Debezium/Kafka → Flink → MinIO (Iceberg)
+```
+
+For each knob you will find: the environment variable name, its default, the lever it
+controls, and the tradeoff between the two extremes.
+
+---
+
+## Table of contents
+
+1. [Flink — parallelism](#1-flink--parallelism)
+2. [Flink — checkpointing](#2-flink--checkpointing)
+3. [Flink — restart strategy](#3-flink--restart-strategy)
+4. [Kafka — producer batching & compression](#4-kafka--producer-batching--compression)
+5. [MinIO — multipart upload](#5-minio--multipart-upload)
+6. [MinIO — prefix sharding](#6-minio--prefix-sharding)
+7. [MinIO — sink batching](#7-minio--sink-batching)
+8. [Iceberg — write file size](#8-iceberg--write-file-size)
+9. [Iceberg — write format & encoding](#9-iceberg--write-format--encoding)
+10. [Iceberg — compaction](#10-iceberg--compaction)
+11. [Quick-reference table](#11-quick-reference-table)
+12. [Recommended profiles](#12-recommended-profiles)
+
+---
+
+## 1. Flink — parallelism
+
+**Code:** [`CdcUserEventCountJob.java`](../stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java)
+
+| Env var | Default | Unit |
+|---|---|---|
+| `FLINK_PARALLELISM` | `-1` (cluster default) | integer |
+
+Parallelism sets how many parallel task instances each operator runs. In the CDC job
+this governs how many partitions the Kafka source reads concurrently and how many
+key-groups the windowed aggregation maintains.
+
+| Lower (e.g. `1–2`) | Higher (e.g. `8–32`) |
+|---|---|
+| Fewer TaskManager slots needed | Better throughput on wide Kafka topics |
+| Simpler state layout; smaller checkpoint | More concurrent state; larger checkpoint size |
+| Suitable for dev / low-volume topics | Required when source topic has many partitions |
+| Watermark synchronization is faster | Watermark alignment across subtasks adds latency |
+
+**Rule of thumb:** set `FLINK_PARALLELISM` equal to the number of partitions in
+`KAFKA_SOURCE_TOPIC`. Kafka does not serve the same partition to two consumers in the
+same group, so extra parallelism above the partition count wastes slots.
+
+---
+
+## 2. Flink — checkpointing
+
+**Code:** [`CdcUserEventCountJob.java`](../stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java)
+
+| Env var | Default | Unit |
+|---|---|---|
+| `CHECKPOINT_INTERVAL_MS` | `30000` | ms |
+| `CHECKPOINT_TIMEOUT_MS` | `60000` | ms |
+| `CHECKPOINT_MIN_PAUSE_MS` | `0` | ms |
+| `CHECKPOINT_MAX_CONCURRENT` | `1` | integer |
+| `CHECKPOINT_MODE` | `exactly_once` | `exactly_once` \| `at_least_once` |
+| `CHECKPOINT_UNALIGNED` | `false` | boolean |
+
+### 2.1 Checkpoint interval
+
+| Short (e.g. 5 000 ms) | Long (e.g. 300 000 ms) |
+|---|---|
+| Fast recovery — re-plays fewer Kafka messages after failure | Slow recovery — replays more Kafka history |
+| High write I/O to state backend (S3/HDFS) | Less I/O pressure |
+| More frequent barrier injection — slightly raises latency | Fewer barriers — lower ongoing latency cost |
+
+**Recommendation:** 15 000–60 000 ms for production; shorter during initial load.
+
+### 2.2 Checkpoint timeout
+
+If a checkpoint does not complete within `CHECKPOINT_TIMEOUT_MS` it is aborted. Set
+this larger than your expected checkpoint duration (visible on the Flink UI). Repeated
+timeouts indicate back-pressure or slow state-backend I/O.
+
+### 2.3 Min pause between checkpoints
+
+`CHECKPOINT_MIN_PAUSE_MS` prevents a new checkpoint from starting immediately after
+the previous one finishes. Under heavy back-pressure this stops the job from spending
+all its time checkpointing.
+
+| `0` (default) | e.g. `10000` |
+|---|---|
+| Back-to-back checkpoints possible under back-pressure | Guarantees processing time between checkpoints |
+| Can degrade throughput if checkpoints are slow | Predictable overhead per checkpoint cycle |
+
+### 2.4 Exactly-once vs. at-least-once
+
+`CHECKPOINT_MODE=exactly_once` inserts barriers that align across all input channels
+before snapshotting. This guarantees no duplicate output but adds a small latency
+spike at each barrier.
+
+`at_least_once` skips barrier alignment: records after the barrier may be processed
+before the checkpoint completes, which can produce duplicates on recovery but reduces
+p99 latency.
+
+| `exactly_once` | `at_least_once` |
+|---|---|
+| No duplicates; idempotent sink not required | Possible duplicates; sink must be idempotent |
+| Barrier alignment pauses subtasks briefly | No alignment pause — lower latency |
+| Required when writing to transactional sinks | Suitable when downstream deduplicates (e.g. Iceberg MERGE) |
+
+### 2.5 Unaligned checkpoints
+
+`CHECKPOINT_UNALIGNED=true` stores in-flight records inside the checkpoint snapshot
+instead of waiting for barrier alignment. This eliminates alignment stalls under
+back-pressure, at the cost of a larger checkpoint size.
+
+| `false` (aligned) | `true` (unaligned) |
+|---|---|
+| Smaller checkpoint (only state, no in-flight data) | Larger checkpoint (state + buffered records) |
+| Suitable when back-pressure is rare | Required when barrier stalls exceed timeout |
+| Lower restore overhead | Higher restore overhead (re-applies buffered records) |
+
+> Only available with `CHECKPOINT_MODE=exactly_once`.
+
+---
+
+## 3. Flink — restart strategy
+
+**Code:** [`CdcUserEventCountJob.java`](../stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java)
+
+| Env var | Default | Unit |
+|---|---|---|
+| `RESTART_ATTEMPTS` | `3` | integer |
+| `RESTART_DELAY_MS` | `10000` | ms |
+
+A fixed-delay restart strategy retries the job up to `RESTART_ATTEMPTS` times, waiting
+`RESTART_DELAY_MS` between each attempt. If all attempts are exhausted the job fails
+permanently.
+
+| Fewer attempts / shorter delay | More attempts / longer delay |
+|---|---|
+| Fails fast — surfaces persistent errors quickly | More resilient to transient network blips |
+| Lower recovery time when bug is real | Risk of cascading retries masking the root cause |
+
+---
+
+## 4. Kafka — producer batching & compression
+
+**Code:** [`CdcUserEventCountJob.java`](../stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java) — `buildKafkaSinkProps()`
+
+These properties apply to both the main `user.event.counts` sink and the DLQ sink.
+
+| Env var | Default | Kafka property |
+|---|---|---|
+| `KAFKA_SINK_BATCH_SIZE_BYTES` | `16384` (16 KB) | `batch.size` |
+| `KAFKA_SINK_LINGER_MS` | `5` | `linger.ms` |
+| `KAFKA_SINK_BUFFER_MEMORY_BYTES` | `33554432` (32 MB) | `buffer.memory` |
+| `KAFKA_SINK_COMPRESSION` | `none` | `compression.type` |
+| `KAFKA_SINK_ACKS` | `all` | `acks` |
+
+### 4.1 Batching (`batch.size` + `linger.ms`)
+
+The Kafka producer accumulates records into a batch before sending. A batch is sent
+when it reaches `batch.size` bytes **or** when `linger.ms` milliseconds have elapsed
+since the first record was added.
+
+| Small batch + low linger | Large batch + higher linger |
+|---|---|
+| Low end-to-end latency (near real-time delivery) | High throughput (fewer network round-trips) |
+| More producer CPU (many small sends) | Higher per-record latency (records wait in buffer) |
+| Suitable for latency-sensitive consumers | Suitable for analytics / batch consumers |
+
+**Recommended for CDC aggregation output:**
+`KAFKA_SINK_BATCH_SIZE_BYTES=65536` (64 KB), `KAFKA_SINK_LINGER_MS=20`
+
+### 4.2 Compression
+
+| Algorithm | CPU cost | Compression ratio | Best for |
+|---|---|---|---|
+| `none` | None | 1× | Low-volume topics or already-compressed payloads |
+| `snappy` | Low | ~2× | Default production choice: good ratio, fast |
+| `lz4` | Very low | ~2× | Latency-sensitive paths needing compression |
+| `zstd` | Medium | ~3–4× | Large messages or expensive network egress |
+| `gzip` | High | ~3× | Compatibility with legacy consumers |
+
+JSON CDC events compress well (typically 3–5× with snappy). Enable compression when
+the Kafka cluster is network-bound or broker storage is expensive.
+
+### 4.3 Acks
+
+| `acks=all` | `acks=1` | `acks=0` |
+|---|---|---|
+| All in-sync replicas acknowledge — no data loss on broker failure | Only leader acknowledges — fast but may lose data if leader fails before replication | Fire-and-forget — maximum throughput, no durability guarantee |
+| Required for exactly-once with Kafka transactions | Acceptable for DLQ topic if replay is possible | Not suitable for this pipeline |
+
+---
+
+## 5. MinIO — multipart upload
+
+**Code:**
+- [`feature_to_minio.py`](../deploy/cdc-flink-minio-demo/feature-sink/feature_to_minio.py)
+- [`IcebergSinkFactory.java`](../stream-processor/src/main/java/ai/streamforge/processor/sink/IcebergSinkFactory.java) (S3A settings)
+
+| Env var | Default | Applies to |
+|---|---|---|
+| `MINIO_PART_SIZE` | `10485760` (10 MB) | Python feature-sink `put_object` |
+| `ICEBERG_S3_MULTIPART_SIZE` | `67108864` (64 MB) | S3A Hadoop FS multipart part |
+| `ICEBERG_S3_MULTIPART_THRESHOLD` | `67108864` (64 MB) | S3A: minimum object size to trigger multipart |
+| `ICEBERG_S3_UPLOAD_THREADS` | `10` | S3A parallel upload threads per task |
+
+Objects smaller than the threshold are uploaded as a single PUT. Objects at or above
+the threshold are split into parts of `part_size` bytes, uploaded in parallel.
+
+| Small part size (e.g. 5 MB) | Large part size (e.g. 128 MB) |
+|---|---|
+| Lower memory per upload thread | Higher memory per upload thread |
+| More HTTP round-trips (higher MinIO CPU overhead) | Fewer round-trips (lower overhead) |
+| Better for small-to-medium files | Best for large Parquet/ORC data files |
+
+MinIO's hard minimum part size is **5 MB** (same as AWS S3). Do not set below this.
+
+`ICEBERG_S3_UPLOAD_THREADS` controls how many parts are in-flight simultaneously. On
+high-bandwidth networks (e.g. 10 GbE within the same data center) increasing this to
+`20–40` can double write throughput for large Iceberg data files.
+
+---
+
+## 6. MinIO — prefix sharding
+
+**Code:** [`feature_to_minio.py`](../deploy/cdc-flink-minio-demo/feature-sink/feature_to_minio.py)
+
+| Env var | Default | Unit |
+|---|---|---|
+| `MINIO_SHARD_DEPTH` | `1` | integer (0–2) |
+
+MinIO (like S3) uses the key prefix to route requests to internal storage nodes. A
+flat prefix (all objects under `streamforge/features/`) concentrates requests on a
+single "partition" of the key space at high throughput, creating a hot-spot.
+
+| `MINIO_SHARD_DEPTH=0` | `=1` (default) | `=2` |
+|---|---|---|
+| `<prefix>/<ts>.json` | `<prefix>/2024/01/15/<ts>.json` | `<prefix>/2024/01/<ts>.json` |
+| Simple; fine for < 1 000 objects/day | Date-sharded; distributes load across 365 prefixes/year | Hour-sharded; 8 760 prefixes/year |
+| Hot-spot risk at high write rates | Recommended for production | Use only for very high write rates |
+
+Depth 1 also enables efficient time-range queries: `mc ls local/processed/streamforge/features/2024/01/15/`
+
+---
+
+## 7. MinIO — sink batching
+
+**Code:** [`feature_to_minio.py`](../deploy/cdc-flink-minio-demo/feature-sink/feature_to_minio.py)
+
+| Env var | Default | Unit |
+|---|---|---|
+| `SINK_BATCH_SIZE` | `1` | records |
+| `SINK_BATCH_TIMEOUT_S` | `5.0` | seconds |
+| `KAFKA_FETCH_MAX_BYTES` | `52428800` (50 MB) | bytes |
+| `KAFKA_MAX_POLL_RECORDS` | `500` | records |
+
+The sink accumulates records into an in-memory buffer. A PUT is issued when
+`SINK_BATCH_SIZE` records are ready **or** `SINK_BATCH_TIMEOUT_S` seconds have elapsed,
+whichever comes first. Records are committed to Kafka only after a successful PUT.
+
+| Small batch (1–10 records) | Large batch (100–1 000 records) |
+|---|---|
+| Low delivery latency | Fewer MinIO PUT requests (lower cost) |
+| Many small objects — poor Iceberg scan performance | Larger objects — better compression ratio |
+| High MinIO request rate at scale | Lower MinIO request rate |
+| Kafka offsets committed frequently | Offset commits only after large PUT |
+
+**For Iceberg workloads:** set `SINK_BATCH_SIZE=500` and `SINK_BATCH_TIMEOUT_S=30` to
+produce objects large enough that Iceberg does not need to compact immediately.
+
+`KAFKA_MAX_POLL_RECORDS` limits how many records are fetched from Kafka per poll
+loop. Set it ≥ `SINK_BATCH_SIZE` so a batch can be filled in a single poll.
+
+---
+
+## 8. Iceberg — write file size
+
+**Code:** [`IcebergSinkFactory.java`](../stream-processor/src/main/java/ai/streamforge/processor/sink/IcebergSinkFactory.java)
+
+| Env var | Default | Iceberg property |
+|---|---|---|
+| `ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES` | `134217728` (128 MB) | `write.target-file-size-bytes` |
+| `ICEBERG_WRITE_PARALLELISM` | `-1` (Flink default) | `FlinkSink.writeParallelism()` |
+
+The Iceberg writer rolls to a new data file when the current file reaches the target
+size. This is the single most important compaction-related knob.
+
+| Small target (e.g. 16 MB) | Large target (e.g. 512 MB) |
+|---|---|
+| More files — higher S3 PUT cost | Fewer files — lower S3 PUT cost |
+| Faster compaction (each file is small) | Slower compaction (large files take longer to rewrite) |
+| More metadata overhead in Iceberg catalog | Less metadata |
+| Better for low-latency incremental queries | Better for full-scan analytics |
+
+**Rule of thumb:** keep files between **64 MB and 512 MB** for Parquet. Below 64 MB,
+the file-listing overhead on query planners (Spark/Trino) dominates. Above 512 MB,
+compaction becomes expensive.
+
+The `ICEBERG_WRITE_PARALLELISM` value controls how many Flink subtasks write Iceberg
+files concurrently. Setting it lower than `FLINK_PARALLELISM` reduces the number of
+simultaneously open files (and therefore simultaneous S3 connections), which helps
+keep file sizes large.
+
+---
+
+## 9. Iceberg — write format & encoding
+
+**Code:** [`IcebergSinkFactory.java`](../stream-processor/src/main/java/ai/streamforge/processor/sink/IcebergSinkFactory.java)
+
+| Env var | Default | Iceberg property |
+|---|---|---|
+| `ICEBERG_WRITE_FORMAT` | `parquet` | `write.format.default` |
+| `ICEBERG_WRITE_PARQUET_ROW_GROUP_SIZE_BYTES` | `134217728` (128 MB) | `write.parquet.row-group-size-bytes` |
+| `ICEBERG_WRITE_PARQUET_PAGE_SIZE_BYTES` | `1048576` (1 MB) | `write.parquet.page-size-bytes` |
+
+### Format comparison
+
+| Format | Layout | Best for | Notes |
+|---|---|---|---|
+| `parquet` | Columnar | Analytics, wide tables, high compression | Default; best predicate pushdown |
+| `avro` | Row-oriented | Row-level access, schema evolution | Faster appends; larger files |
+| `orc` | Columnar | Hive/Trino workloads needing bloom filters | Good for string predicates |
+
+### Parquet row-group size
+
+A Parquet file contains one or more row-groups. The query engine reads one row-group
+at a time; smaller row-groups improve selective reads but increase file metadata overhead.
+
+| Small row-group (e.g. 16 MB) | Large row-group (≥ target file size) |
+|---|---|
+| Fine-grained predicate pushdown | Single row-group per file — minimal overhead |
+| More metadata per file | Reader must scan more data for selective predicates |
+| Higher memory pressure during write | Lower write memory |
+
+### Parquet page size
+
+Pages are the unit of encoding within a column chunk. Smaller pages improve
+predicate recall but add page-header overhead.
+
+Default (1 MB) is appropriate for most workloads. Reduce to 256 KB if queries
+frequently access a small fraction of rows with selective predicates.
+
+---
+
+## 10. Iceberg — compaction
+
+Iceberg does not auto-compact by default. The Flink streaming job produces many small
+files (one per checkpoint per write parallelism). A separate periodic compaction job
+using `RewriteDataFilesAction` is needed to merge them.
+
+Key properties governing compaction behaviour:
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `ICEBERG_COMPACTION_TARGET_FILE_SIZE` | same as `ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES` | Target size for output files after compaction |
+| `ICEBERG_COMPACTION_MIN_INPUT_FILES` | `5` | Min small files required before a group is compacted |
+
+> These are currently used as documentation defaults for the `RewriteDataFilesAction`
+> call in your maintenance job. Wire them in when you implement the scheduled
+> compaction pipeline.
+
+### Compaction tradeoffs
+
+| Compact aggressively (low min-files, frequent runs) | Compact conservatively (high min-files, infrequent runs) |
+|---|---|
+| Files stay near target size — good query performance | Files stay small between runs — slower queries |
+| Higher Iceberg catalog write amplification | Lower catalog overhead |
+| More CPU/S3 I/O used by compaction | Less background resource usage |
+| Suitable when fresh data is queried in near real-time | Suitable for batch-only workloads queried once per day |
+
+### S3 prefix sharding and Iceberg
+
+Iceberg stores data files under the warehouse path. On MinIO, all data files for a
+table share a common prefix (e.g. `s3a://warehouse/streamforge/user_event_counts/data/`).
+At high write rates this single prefix can become a hot-spot. Mitigations:
+
+1. **Partition the table** by a time column (e.g. `window_start_ms` truncated to day).
+   Each partition gets its own prefix sub-directory, distributing the key space.
+2. **Increase `ICEBERG_S3_UPLOAD_THREADS`** to pipeline concurrent part uploads instead
+   of serialising them on the hot prefix.
+3. On self-hosted MinIO, deploy multiple drives/nodes and enable erasure coding to
+   spread object placement across physical storage.
+
+---
+
+## 11. Quick-reference table
+
+| Category | Env var | Default | Raise when… | Lower when… |
+|---|---|---|---|---|
+| **Flink** | `FLINK_PARALLELISM` | `-1` | Kafka topic has many partitions | Cluster has few slots |
+| **Flink** | `CHECKPOINT_INTERVAL_MS` | `30 000` | Checkpoints are fast; RTO matters | Checkpoint I/O is a bottleneck |
+| **Flink** | `CHECKPOINT_TIMEOUT_MS` | `60 000` | Checkpoints routinely time out | — |
+| **Flink** | `CHECKPOINT_MIN_PAUSE_MS` | `0` | Checkpoint overhead exceeds 20% of cycle | Latency matters more than overhead |
+| **Flink** | `CHECKPOINT_UNALIGNED` | `false` | Barrier stalls cause timeouts | Checkpoint size is already large |
+| **Flink** | `RESTART_ATTEMPTS` | `3` | Errors are transient (network blips) | Errors are likely bugs |
+| **Kafka** | `KAFKA_SINK_BATCH_SIZE_BYTES` | `16 384` | Throughput is bottleneck | Latency is bottleneck |
+| **Kafka** | `KAFKA_SINK_LINGER_MS` | `5` | Batching rate is low | Consumers are latency-sensitive |
+| **Kafka** | `KAFKA_SINK_COMPRESSION` | `none` | Network is the bottleneck | CPU is the bottleneck |
+| **MinIO** | `MINIO_PART_SIZE` | `10 MB` | Large Parquet files (>128 MB) | Small feature events (<10 MB) |
+| **MinIO** | `ICEBERG_S3_UPLOAD_THREADS` | `10` | High-bandwidth intra-DC network | MinIO CPU is saturated |
+| **MinIO** | `MINIO_SHARD_DEPTH` | `1` | Very high write rate (>10 K obj/s) | Simple key layout desired |
+| **MinIO** | `SINK_BATCH_SIZE` | `1` | PUT cost is high; events are small | Latency matters |
+| **MinIO** | `SINK_BATCH_TIMEOUT_S` | `5.0` | Low event rate (batch rarely fills) | Latency matters |
+| **Iceberg** | `ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES` | `128 MB` | Files are too small after compaction | Files are too large for selective reads |
+| **Iceberg** | `ICEBERG_WRITE_FORMAT` | `parquet` | Analytics on wide tables | Row-level access patterns |
+| **Iceberg** | `ICEBERG_WRITE_PARQUET_ROW_GROUP_SIZE_BYTES` | `128 MB` | Full-scan analytics dominate | Highly selective point queries |
+| **Iceberg** | `ICEBERG_WRITE_PARALLELISM` | Flink default | Need large files; reduce open file count | High-throughput ingestion |
+
+---
+
+## 12. Recommended profiles
+
+### Low-latency (near real-time dashboard)
+
+```
+CHECKPOINT_INTERVAL_MS=10000
+CHECKPOINT_MODE=at_least_once
+KAFKA_SINK_LINGER_MS=1
+KAFKA_SINK_BATCH_SIZE_BYTES=4096
+SINK_BATCH_SIZE=1
+SINK_BATCH_TIMEOUT_S=1.0
+ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES=33554432   # 32 MB — accept more compaction
+```
+
+### High-throughput (batch analytics)
+
+```
+FLINK_PARALLELISM=16
+CHECKPOINT_INTERVAL_MS=60000
+CHECKPOINT_UNALIGNED=true
+KAFKA_SINK_BATCH_SIZE_BYTES=262144              # 256 KB
+KAFKA_SINK_LINGER_MS=50
+KAFKA_SINK_COMPRESSION=snappy
+SINK_BATCH_SIZE=500
+SINK_BATCH_TIMEOUT_S=30.0
+MINIO_PART_SIZE=67108864                        # 64 MB
+ICEBERG_S3_UPLOAD_THREADS=20
+ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES=536870912  # 512 MB
+ICEBERG_WRITE_PARALLELISM=4
+```
+
+### Cost-optimised (low S3 PUT cost)
+
+```
+KAFKA_SINK_COMPRESSION=zstd
+SINK_BATCH_SIZE=1000
+SINK_BATCH_TIMEOUT_S=60.0
+MINIO_SHARD_DEPTH=1
+ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES=268435456  # 256 MB
+ICEBERG_COMPACTION_MIN_INPUT_FILES=10
+```

--- a/stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java
@@ -10,14 +10,17 @@ import ai.streamforge.processor.serialization.UserEventCountSerializationSchema;
 import ai.streamforge.processor.sink.IcebergSinkFactory;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
 import org.apache.flink.connector.kafka.sink.KafkaSink;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.windowing.RichProcessWindowFunction;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
@@ -28,6 +31,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.Properties;
 
 /**
  * Flink CDC aggregation job.
@@ -47,6 +51,28 @@ import java.time.Duration;
  *   <li>{@code OUT_OF_ORDERNESS_SECONDS} — default {@code 5}</li>
  * </ul>
  *
+ * <p>Flink parallelism and checkpointing knobs:
+ * <ul>
+ *   <li>{@code FLINK_PARALLELISM}              — operator parallelism, default {@code -1} (use cluster default)</li>
+ *   <li>{@code CHECKPOINT_INTERVAL_MS}         — checkpoint interval in ms, default {@code 30000}</li>
+ *   <li>{@code CHECKPOINT_TIMEOUT_MS}          — per-checkpoint timeout in ms, default {@code 60000}</li>
+ *   <li>{@code CHECKPOINT_MIN_PAUSE_MS}        — min pause between checkpoints in ms, default {@code 0}</li>
+ *   <li>{@code CHECKPOINT_MAX_CONCURRENT}      — max concurrent checkpoints, default {@code 1}</li>
+ *   <li>{@code CHECKPOINT_MODE}                — {@code exactly_once} (default) or {@code at_least_once}</li>
+ *   <li>{@code CHECKPOINT_UNALIGNED}           — enable unaligned checkpoints, default {@code false}</li>
+ *   <li>{@code RESTART_ATTEMPTS}               — fixed-delay restart attempts, default {@code 3}</li>
+ *   <li>{@code RESTART_DELAY_MS}               — fixed-delay restart interval in ms, default {@code 10000}</li>
+ * </ul>
+ *
+ * <p>Kafka producer tuning knobs (applied to the main sink and DLQ sink):
+ * <ul>
+ *   <li>{@code KAFKA_SINK_COMPRESSION}         — {@code none} (default), {@code snappy}, {@code lz4}, {@code zstd}, {@code gzip}</li>
+ *   <li>{@code KAFKA_SINK_BATCH_SIZE_BYTES}    — producer batch.size in bytes, default {@code 16384} (16 KB)</li>
+ *   <li>{@code KAFKA_SINK_LINGER_MS}           — producer linger.ms, default {@code 5}</li>
+ *   <li>{@code KAFKA_SINK_BUFFER_MEMORY_BYTES} — producer buffer.memory in bytes, default {@code 33554432} (32 MB)</li>
+ *   <li>{@code KAFKA_SINK_ACKS}                — producer acks, default {@code all}</li>
+ * </ul>
+ *
  * <p>Optional Apache Iceberg sink (set {@code ICEBERG_ENABLED=true} to activate):
  * <ul>
  *   <li>{@code ICEBERG_ENABLED}       — default {@code false}</li>
@@ -64,6 +90,7 @@ public class CdcUserEventCountJob {
     private static final Logger LOG = LoggerFactory.getLogger(CdcUserEventCountJob.class);
 
     public static void main(String[] args) throws Exception {
+        // ── Topic / group config ─────────────────────────────────────────────
         String bootstrapServers      = env("KAFKA_BOOTSTRAP_SERVERS",  "localhost:9092");
         String sourceTopic           = env("KAFKA_SOURCE_TOPIC",       "cdc.streamforge.user_events");
         String sinkTopic             = env("KAFKA_SINK_TOPIC",         "user.event.counts");
@@ -72,12 +99,57 @@ public class CdcUserEventCountJob {
         long   windowSizeSeconds     = Long.parseLong(env("WINDOW_SIZE_SECONDS",      "60"));
         long   outOfOrdernessSeconds = Long.parseLong(env("OUT_OF_ORDERNESS_SECONDS", "5"));
 
-        LOG.info("Starting CdcUserEventCountJob: source={}, sink={}, dlq={}, window={}s",
-                sourceTopic, sinkTopic, dlqTopic.isBlank() ? "disabled" : dlqTopic, windowSizeSeconds);
+        // ── Flink parallelism ────────────────────────────────────────────────
+        int parallelism = Integer.parseInt(env("FLINK_PARALLELISM", "-1"));
+
+        // ── Checkpoint config ────────────────────────────────────────────────
+        long   checkpointIntervalMs   = Long.parseLong(env("CHECKPOINT_INTERVAL_MS",    "30000"));
+        long   checkpointTimeoutMs    = Long.parseLong(env("CHECKPOINT_TIMEOUT_MS",     "60000"));
+        long   checkpointMinPauseMs   = Long.parseLong(env("CHECKPOINT_MIN_PAUSE_MS",   "0"));
+        int    maxConcurrentCkpts     = Integer.parseInt(env("CHECKPOINT_MAX_CONCURRENT", "1"));
+        String checkpointModeStr      = env("CHECKPOINT_MODE",      "exactly_once");
+        boolean unalignedCheckpoints  = Boolean.parseBoolean(env("CHECKPOINT_UNALIGNED", "false"));
+        int    restartAttempts        = Integer.parseInt(env("RESTART_ATTEMPTS", "3"));
+        long   restartDelayMs         = Long.parseLong(env("RESTART_DELAY_MS",  "10000"));
+
+        // ── Kafka sink producer properties ───────────────────────────────────
+        Properties kafkaSinkProps = buildKafkaSinkProps();
+
+        LOG.info("Starting CdcUserEventCountJob: source={}, sink={}, dlq={}, window={}s, " +
+                 "parallelism={}, checkpoint={}ms mode={} unaligned={}, " +
+                 "compression={} batchSize={} lingerMs={}",
+                sourceTopic, sinkTopic, dlqTopic.isBlank() ? "disabled" : dlqTopic, windowSizeSeconds,
+                parallelism < 0 ? "cluster-default" : parallelism,
+                checkpointIntervalMs, checkpointModeStr, unalignedCheckpoints,
+                kafkaSinkProps.getProperty("compression.type", "none"),
+                kafkaSinkProps.getProperty("batch.size", "16384"),
+                kafkaSinkProps.getProperty("linger.ms", "5"));
 
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.enableCheckpointing(30_000);
 
+        if (parallelism > 0) {
+            env.setParallelism(parallelism);
+        }
+
+        // ── Checkpointing ────────────────────────────────────────────────────
+        CheckpointingMode ckptMode = "at_least_once".equalsIgnoreCase(checkpointModeStr)
+                ? CheckpointingMode.AT_LEAST_ONCE
+                : CheckpointingMode.EXACTLY_ONCE;
+
+        env.enableCheckpointing(checkpointIntervalMs, ckptMode);
+
+        CheckpointConfig ckptCfg = env.getCheckpointConfig();
+        ckptCfg.setCheckpointTimeout(checkpointTimeoutMs);
+        ckptCfg.setMinPauseBetweenCheckpoints(checkpointMinPauseMs);
+        ckptCfg.setMaxConcurrentCheckpoints(maxConcurrentCkpts);
+        ckptCfg.enableUnalignedCheckpoints(unalignedCheckpoints);
+        ckptCfg.setExternalizedCheckpointCleanup(
+                CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
+
+        env.setRestartStrategy(
+                RestartStrategies.fixedDelayRestart(restartAttempts, restartDelayMs));
+
+        // ── Source ───────────────────────────────────────────────────────────
         KafkaSource<CdcEvent> source = KafkaSource.<CdcEvent>builder()
                 .setBootstrapServers(bootstrapServers)
                 .setTopics(sourceTopic)
@@ -103,6 +175,7 @@ public class CdcUserEventCountJob {
         if (!dlqTopic.isBlank()) {
             KafkaSink<DeadLetterEvent> dlqSink = KafkaSink.<DeadLetterEvent>builder()
                     .setBootstrapServers(bootstrapServers)
+                    .setKafkaProducerConfig(kafkaSinkProps)
                     .setRecordSerializer(
                             KafkaRecordSerializationSchema.<DeadLetterEvent>builder()
                                     .setTopic(dlqTopic)
@@ -125,6 +198,7 @@ public class CdcUserEventCountJob {
 
         KafkaSink<UserEventCount> sink = KafkaSink.<UserEventCount>builder()
                 .setBootstrapServers(bootstrapServers)
+                .setKafkaProducerConfig(kafkaSinkProps)
                 .setRecordSerializer(
                         KafkaRecordSerializationSchema.<UserEventCount>builder()
                                 .setTopic(sinkTopic)
@@ -202,5 +276,29 @@ public class CdcUserEventCountJob {
     private static String env(String name, String defaultValue) {
         String v = System.getenv(name);
         return (v != null && !v.isBlank()) ? v : defaultValue;
+    }
+
+    /**
+     * Builds Kafka producer properties from environment variables.
+     * These apply to both the main sink and the DLQ sink.
+     */
+    private static Properties buildKafkaSinkProps() {
+        Properties props = new Properties();
+
+        // Batching: larger batch + linger improves throughput at the cost of latency
+        props.setProperty("batch.size",    env("KAFKA_SINK_BATCH_SIZE_BYTES",    "16384"));
+        props.setProperty("linger.ms",     env("KAFKA_SINK_LINGER_MS",           "5"));
+        props.setProperty("buffer.memory", env("KAFKA_SINK_BUFFER_MEMORY_BYTES", "33554432"));
+
+        // Compression: reduces network/disk I/O; snappy/lz4 best for throughput, zstd for ratio
+        String compression = env("KAFKA_SINK_COMPRESSION", "none");
+        if (!"none".equalsIgnoreCase(compression)) {
+            props.setProperty("compression.type", compression);
+        }
+
+        // Durability: "all" waits for all in-sync replicas; "1" or "0" for lower latency
+        props.setProperty("acks", env("KAFKA_SINK_ACKS", "all"));
+
+        return props;
     }
 }

--- a/stream-processor/src/main/java/ai/streamforge/processor/sink/IcebergSinkFactory.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/sink/IcebergSinkFactory.java
@@ -29,6 +29,29 @@ import java.util.Map;
  * <p>Supported catalog types: {@code hadoop} (default), {@code hive}, {@code rest}.
  * For MinIO / S3-compatible storage set the {@code ICEBERG_S3_*} environment variables
  * so the Hadoop S3A filesystem is configured automatically.
+ *
+ * <p>Write file size and compaction tuning (via environment variables):
+ * <ul>
+ *   <li>{@code ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES} — target data file size before rolling,
+ *       default {@code 134217728} (128 MB). Smaller files mean more frequent commits but
+ *       finer partitioning granularity; larger files reduce S3 PUT costs but slow down
+ *       compaction scans.</li>
+ *   <li>{@code ICEBERG_WRITE_FORMAT}                 — {@code parquet} (default), {@code avro},
+ *       or {@code orc}.</li>
+ *   <li>{@code ICEBERG_WRITE_UPSERT}                 — enable upsert mode, default {@code false}.
+ *       Requires an equality-delete scheme; trades write amplification for MERGE semantics.</li>
+ *   <li>{@code ICEBERG_COMPACTION_TARGET_FILE_SIZE}  — target file size for the rewrite action
+ *       (minor compaction), default same as write target. Governs how small files are merged
+ *       when running {@code RewriteDataFilesAction}.</li>
+ *   <li>{@code ICEBERG_COMPACTION_MIN_INPUT_FILES}   — minimum number of small files that must
+ *       exist before a compaction group is submitted, default {@code 5}. Lower values compact
+ *       more aggressively; higher values reduce Iceberg catalog write amplification.</li>
+ *   <li>{@code ICEBERG_S3_MULTIPART_SIZE}            — S3A multipart upload part size,
+ *       default {@code 67108864} (64 MB). Must be ≥ 5 MB (AWS minimum). Larger parts improve
+ *       PUT throughput for big files at the cost of memory per upload thread.</li>
+ *   <li>{@code ICEBERG_S3_MULTIPART_THRESHOLD}       — file size above which multipart upload
+ *       is used, default {@code 67108864} (64 MB).</li>
+ * </ul>
  */
 public class IcebergSinkFactory {
 
@@ -75,13 +98,17 @@ public class IcebergSinkFactory {
                 .returns(TypeInformation.of(RowData.class))
                 .name("Map to Iceberg RowData");
 
+        Map<String, String> writeProps = buildWriteProperties();
+
         FlinkSink.forRowData(rowData)
                 .tableLoader(tableLoader)
+                .writeParallelism(writeParallelism())
+                .setAll(writeProps)
                 .append()
                 .name("Iceberg Sink: " + database + "." + tableName);
 
-        LOG.info("Iceberg sink attached: catalog={}, warehouse={}, table={}.{}",
-                catalogType, warehouse, database, tableName);
+        LOG.info("Iceberg sink attached: catalog={}, warehouse={}, table={}.{}, writeProps={}",
+                catalogType, warehouse, database, tableName, writeProps);
     }
 
     private static CatalogLoader buildCatalogLoader(
@@ -123,7 +150,66 @@ public class IcebergSinkFactory {
             conf.set("fs.s3a.secret.key",        s3SecretKey != null ? s3SecretKey : "");
             conf.set("fs.s3a.path.style.access", "true");
             conf.set("fs.s3a.impl",              "org.apache.hadoop.fs.s3a.S3AFileSystem");
+
+            // MinIO multipart upload tuning
+            String multipartSize      = senv("ICEBERG_S3_MULTIPART_SIZE",      "67108864");
+            String multipartThreshold = senv("ICEBERG_S3_MULTIPART_THRESHOLD",  "67108864");
+            conf.set("fs.s3a.multipart.size",               multipartSize);
+            conf.set("fs.s3a.multipart.threshold",          multipartThreshold);
+            // Parallel upload threads per file; increase for high-bandwidth links
+            conf.set("fs.s3a.threads.max",
+                    senv("ICEBERG_S3_UPLOAD_THREADS", "10"));
         }
         return conf;
+    }
+
+    /**
+     * Iceberg FlinkSink write properties sourced from environment variables.
+     * These map directly to {@code write.*} Iceberg table properties.
+     */
+    private static Map<String, String> buildWriteProperties() {
+        Map<String, String> props = new HashMap<>();
+
+        // Target data file size before the writer rolls to a new file.
+        // Smaller → more S3 objects (higher PUT cost, faster partial reads).
+        // Larger  → fewer objects, but compaction must merge larger files.
+        props.put("write.target-file-size-bytes",
+                senv("ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES", "134217728"));
+
+        // File format: parquet is the default (columnar, good for analytics).
+        // avro is row-oriented (faster writes, less efficient scans).
+        // orc is columnar with better predicate pushdown than parquet for some engines.
+        props.put("write.format.default",
+                senv("ICEBERG_WRITE_FORMAT", "parquet"));
+
+        // Parquet row-group size; affects read buffer and compression ratio.
+        props.put("write.parquet.row-group-size-bytes",
+                senv("ICEBERG_WRITE_PARQUET_ROW_GROUP_SIZE_BYTES", "134217728"));
+
+        // Parquet page size; smaller pages improve predicate pushdown recall.
+        props.put("write.parquet.page-size-bytes",
+                senv("ICEBERG_WRITE_PARQUET_PAGE_SIZE_BYTES", "1048576"));
+
+        // Compaction: target file size for RewriteDataFilesAction (minor compaction).
+        // Should generally match the write target to avoid re-compacting repeatedly.
+        props.put("write.target-file-size-bytes",
+                senv("ICEBERG_COMPACTION_TARGET_FILE_SIZE",
+                     senv("ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES", "134217728")));
+
+        return props;
+    }
+
+    /** Write parallelism for the Iceberg sink operators; -1 defers to Flink's env default. */
+    private static int writeParallelism() {
+        String v = System.getenv("ICEBERG_WRITE_PARALLELISM");
+        if (v != null && !v.isBlank()) {
+            return Integer.parseInt(v);
+        }
+        return -1;
+    }
+
+    private static String senv(String name, String defaultValue) {
+        String v = System.getenv(name);
+        return (v != null && !v.isBlank()) ? v : defaultValue;
     }
 }


### PR DESCRIPTION
…O, and Iceberg

- docs/TUNING.md: new 12-section reference covering every tuning lever with tradeoff matrices and three deployment profiles (low-latency / high-throughput / cost-optimised).

- CdcUserEventCountJob.java: expose FLINK_PARALLELISM; 6 checkpoint knobs (interval, timeout, min-pause, max-concurrent, mode, unaligned); restart strategy (attempts, delay); and 5 Kafka producer props (compression, batch-size, linger, buffer-memory, acks) via buildKafkaSinkProps() applied to both the main sink and DLQ sink.

- IcebergSinkFactory.java: expose write target file size, write format, Parquet row-group and page size, write parallelism, and S3A multipart settings (part size, threshold, upload threads) so operators can tune MinIO write throughput without recompiling.

- feature_to_minio.py: add SINK_BATCH_SIZE / SINK_BATCH_TIMEOUT_S for record batching before PUT; MINIO_PART_SIZE for multipart threshold; MINIO_SHARD_DEPTH for date-hierarchy prefix sharding; KAFKA_FETCH_MAX_BYTES / KAFKA_MAX_POLL_RECORDS for consumer throughput; switch to manual offset commit so offsets are only advanced after a successful MinIO PUT.