### PR TITLE
feat(iceberg): promote Iceberg to first-class sink with partitioning,…

### DIFF
--- a/deploy/cdc-flink-minio-demo/docker-compose.yml
+++ b/deploy/cdc-flink-minio-demo/docker-compose.yml
@@ -149,3 +149,53 @@ services:
       MINIO_SECRET_KEY: minioadmin
       MINIO_BUCKET: processed
       MINIO_PREFIX: streamforge/features
+
+  # ── Iceberg table maintenance ────────────────────────────────────────────────
+  # Runs on startup and then every MAINTENANCE_INTERVAL_SECONDS (default 3 600 s / 1 h).
+  # Phase 1: expire snapshots older than SNAPSHOT_MAX_AGE_HOURS.
+  # Phase 2: compact fragmented manifests.
+  # Phase 3: report partitions with small data files.
+  #
+  # To trigger an immediate manual run:
+  #   docker compose exec iceberg-maintenance \
+  #     java -cp /opt/stream-processor/stream-processor-*.jar \
+  #     ai.streamforge.processor.maintenance.IcebergMaintenanceJob
+  #
+  # To run in dry-run mode (report only, no commits):
+  #   DRY_RUN=true docker compose up iceberg-maintenance
+  iceberg-maintenance:
+    image: flink:1.18.1-java17
+    depends_on:
+      - minio-init
+      - jobmanager
+    entrypoint: >
+      /bin/bash -c "
+        INTERVAL=$${MAINTENANCE_INTERVAL_SECONDS:-3600}
+        echo '[maintenance] Starting Iceberg maintenance loop (interval=$${INTERVAL}s)'
+        while true; do
+          echo '[maintenance] Running at '$(date -u +%Y-%m-%dT%H:%M:%SZ)
+          java -cp /opt/stream-processor/stream-processor-*.jar \
+            ai.streamforge.processor.maintenance.IcebergMaintenanceJob \
+            || echo '[maintenance] Run failed — will retry next interval'
+          echo '[maintenance] Sleeping $${INTERVAL}s'
+          sleep $${INTERVAL}
+        done
+      "
+    environment:
+      ICEBERG_CATALOG_TYPE: hadoop
+      ICEBERG_WAREHOUSE: s3a://streamforge/warehouse
+      ICEBERG_DATABASE: streamforge
+      ICEBERG_TABLE: user_event_counts
+      ICEBERG_S3_ENDPOINT: http://minio:9000
+      ICEBERG_S3_ACCESS_KEY: minioadmin
+      ICEBERG_S3_SECRET_KEY: minioadmin
+      # Retention: expire snapshots older than 7 days, always keep ≥ 10
+      SNAPSHOT_MAX_AGE_HOURS: "168"
+      SNAPSHOT_RETAIN_LAST: "10"
+      # Flag files smaller than 64 MB as compaction candidates
+      COMPACT_SMALL_FILE_THRESHOLD_BYTES: "67108864"
+      # How often maintenance runs (seconds); override via env for faster iteration
+      MAINTENANCE_INTERVAL_SECONDS: "3600"
+      DRY_RUN: "false"
+    volumes:
+      - ../../stream-processor/target:/opt/stream-processor:ro

--- a/docs/ICEBERG_OPERATIONS.md
+++ b/docs/ICEBERG_OPERATIONS.md
@@ -1,0 +1,404 @@
+# Iceberg Operations Guide — StreamForge Analytics Store
+
+Iceberg is the primary analytics sink for StreamForge. This document covers the
+table's design decisions, how maintenance runs, and how to operate it day-to-day.
+
+---
+
+## Table of contents
+
+1. [Table design](#1-table-design)
+2. [Partitioning strategy](#2-partitioning-strategy)
+3. [Data-file compaction](#3-data-file-compaction)
+4. [Snapshot retention policy](#4-snapshot-retention-policy)
+5. [Manifest compaction](#5-manifest-compaction)
+6. [Automated maintenance service](#6-automated-maintenance-service)
+7. [Manual runbook](#7-manual-runbook)
+8. [Querying the table](#8-querying-the-table)
+9. [Schema evolution](#9-schema-evolution)
+
+---
+
+## 1. Table design
+
+**Location:** `$ICEBERG_WAREHOUSE/streamforge/user_event_counts/`
+
+**Schema:**
+
+| Column | Type | Nullable | Notes |
+|---|---|---|---|
+| `user_id` | STRING | NOT NULL | Debezium source `user_id` |
+| `event_count` | LONG | NOT NULL | Insert events in the window |
+| `window_start_ms` | LONG | NOT NULL | Tumbling window start (epoch ms, UTC) |
+| `window_end_ms` | LONG | NOT NULL | Tumbling window end (epoch ms, UTC) |
+| `event_date` | STRING | NOT NULL | `YYYY-MM-DD` UTC date of `window_start_ms` |
+
+Field IDs 1–5 are stable. New optional columns must use field IDs ≥ 6 to preserve
+backward compatibility with existing data files.
+
+**Default write format:** Parquet (columnar, best for analytics on `event_count` and
+`window_start_ms` aggregations).
+
+---
+
+## 2. Partitioning strategy
+
+The table is partitioned by **`identity(event_date)`**.
+
+Each calendar day (UTC) maps to exactly one directory under the table's data path:
+
+```
+warehouse/streamforge/user_event_counts/data/
+  event_date=2024-01-14/
+    00000-0-<uuid>-00001.parquet
+    00000-0-<uuid>-00002.parquet
+  event_date=2024-01-15/
+    00000-0-<uuid>-00001.parquet
+```
+
+### Why identity on a string date rather than a timestamp transform?
+
+| Design choice | Reason |
+|---|---|
+| **Identity on derived string** rather than `day(window_start_ms)` | Avoids a hidden integer-to-date transform that differs between engines; the string value is human-readable in the path and easy to filter with SQL `WHERE event_date BETWEEN '...' AND '...'` |
+| **UTC calendar day** | Consistent with Debezium `ts_ms` (always UTC) and avoids DST boundary confusion |
+| **Day granularity** rather than hour/month | One day is the natural compaction unit for streaming workloads with < 1 M events/day; reduces partition count compared to hourly |
+
+### Partition pruning
+
+Query engines that support Iceberg partition pruning (Spark, Trino, Flink SQL) will
+skip all partitions outside the predicate range. Example:
+
+```sql
+-- Trino: scans only the 2024-01-15 partition directory
+SELECT user_id, SUM(event_count)
+FROM   iceberg.streamforge.user_event_counts
+WHERE  event_date = '2024-01-15'
+GROUP  BY user_id;
+```
+
+Without the `event_date` predicate, a full table scan is required (all partitions).
+
+### Late data
+
+If a Flink window fires late (e.g., `OUT_OF_ORDERNESS_SECONDS` is exceeded), the
+record's `event_date` is derived from `window_start_ms` — the window's own clock,
+not the wall clock. The record lands in the correct historical partition.
+Iceberg's append model means late records do not rewrite existing files.
+
+---
+
+## 3. Data-file compaction
+
+### Why it is needed
+
+The Flink streaming writer creates one data file per checkpoint per write-parallelism
+subtask. With default settings (30 s checkpoint, parallelism 2):
+- 2 files × 2/min × 60 min × 24 h = **5 760 files per day**
+
+A query planning a single day must list and evaluate all 5 760 files. File-listing
+overhead in S3 / MinIO dominates query latency at this scale.
+
+Target state: **8–32 files per day partition** (128 MB each at the 128 MB file target).
+
+### How to run data-file compaction
+
+Data-file compaction requires a compute engine. The recommended approach is a
+one-shot Flink batch job using the Iceberg Flink actions:
+
+```bash
+# Run from stream-processor directory after mvn package
+
+# Compact one specific partition (e.g. yesterday)
+flink run \
+  --class org.apache.iceberg.flink.actions.Actions \
+  -Diceberg.catalog.type=hadoop \
+  -Diceberg.warehouse=s3a://streamforge/warehouse \
+  target/stream-processor-*.jar \
+  rewrite-data-files \
+  --table streamforge.user_event_counts \
+  --target-file-size-bytes 134217728 \
+  --where "event_date='$(date -u -d 'yesterday' +%Y-%m-%d)'"
+
+# Compact all partitions with files smaller than 64 MB
+flink run \
+  --class org.apache.iceberg.flink.actions.Actions \
+  -Diceberg.catalog.type=hadoop \
+  -Diceberg.warehouse=s3a://streamforge/warehouse \
+  target/stream-processor-*.jar \
+  rewrite-data-files \
+  --table streamforge.user_event_counts \
+  --target-file-size-bytes 134217728 \
+  --min-file-size-bytes 67108864 \
+  --max-file-size-bytes 201326592
+```
+
+### When to compact
+
+The `IcebergMaintenanceJob` (§6) reports which day partitions contain small files.
+A partition needs compaction when:
+- It has ≥ 5 files all smaller than 64 MB, **or**
+- It has > 50 files of any size (manifest-list overhead)
+
+Suggested schedule: **nightly at 02:00 UTC** for the previous day's partition.
+
+### Compaction tuning
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `--target-file-size-bytes` | `134217728` (128 MB) | Match `ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES` |
+| `--min-file-size-bytes` | `67108864` (64 MB) | Files above this are not considered small |
+| `--max-file-size-bytes` | `201326592` (192 MB) | Files above this are not split |
+| `--max-concurrent-file-group-rewrites` | `5` | Parallel compaction groups |
+
+---
+
+## 4. Snapshot retention policy
+
+Every Flink checkpoint that writes to Iceberg creates a new snapshot. Default
+checkpoint interval is 30 s → 2 snapshots/min → **2 880 snapshots/day**.
+
+Retaining all snapshots indefinitely fills S3 with orphan manifest and delete files.
+The retention policy is:
+
+| Setting | Default | Effect |
+|---|---|---|
+| `SNAPSHOT_MAX_AGE_HOURS` | `168` (7 days) | Expire snapshots older than 7 days |
+| `SNAPSHOT_RETAIN_LAST` | `10` | Never expire the 10 most recent snapshots, even if older than the age limit |
+
+These ensure:
+- **7-day point-in-time recovery** — any snapshot from the past week can be read via
+  `AS OF SNAPSHOT <id>` or `AS OF TIMESTAMP '...'`.
+- **Minimum 10 snapshots** — prevents accidental full expiry during low-traffic windows.
+
+### How expiry works
+
+`IcebergMaintenanceJob` calls `table.expireSnapshots()` which:
+1. Marks snapshots for deletion (those older than `expiryBeforeMs` and beyond `retainLast`).
+2. Deletes the associated manifest files that are no longer referenced by any live snapshot.
+3. Deletes position-delete and equality-delete files that are only referenced by expired snapshots.
+4. Does **not** delete data files — data files may be shared across snapshots (append-only).
+
+Data files are only removed if **all** snapshots that reference them are expired AND
+the data file itself is an orphan (not referenced by any current manifest). Orphan
+file cleanup is a separate operation (not implemented in this pipeline; run
+`RemoveOrphanFilesAction` if needed).
+
+### Changing the retention window
+
+```bash
+# Extend to 30-day retention (for compliance requirements)
+SNAPSHOT_MAX_AGE_HOURS=720 SNAPSHOT_RETAIN_LAST=50 \
+  docker compose up iceberg-maintenance
+
+# Reduce to 24-hour retention (cost-sensitive low-traffic env)
+SNAPSHOT_MAX_AGE_HOURS=24 SNAPSHOT_RETAIN_LAST=5 \
+  docker compose up iceberg-maintenance
+```
+
+---
+
+## 5. Manifest compaction
+
+Each snapshot appended by the Flink writer adds one new manifest file to the table's
+manifest list. After 1 000 checkpoints the manifest list has 1 000 entries; Iceberg
+must open and parse all of them to plan a scan.
+
+`IcebergMaintenanceJob` runs `table.rewriteManifests()` which merges all manifest
+files into the minimum number of manifests that fit within the target manifest size
+(default 8 MB per manifest).
+
+**Impact:** reduces scan-planning time proportionally to the manifest count reduction.
+A table with 2 880 manifests/day compacted to ~1 per day reduces planning overhead by
+~99% for single-day scans.
+
+Manifest compaction is cheap (read-only on data files; writes only new manifest
+files) and runs automatically with each maintenance cycle.
+
+---
+
+## 6. Automated maintenance service
+
+The `iceberg-maintenance` container in `deploy/cdc-flink-minio-demo/docker-compose.yml`
+runs `IcebergMaintenanceJob` on a loop:
+
+```
+startup → Phase 1 (expire snapshots)
+        → Phase 2 (compact manifests)
+        → Phase 3 (report small files)
+        → sleep MAINTENANCE_INTERVAL_SECONDS
+        → repeat
+```
+
+**Default interval:** 3 600 s (1 hour).
+
+### Override the interval for development
+
+```bash
+MAINTENANCE_INTERVAL_SECONDS=60 docker compose up iceberg-maintenance
+```
+
+### Dry-run mode (report only, no commits)
+
+```bash
+DRY_RUN=true docker compose up iceberg-maintenance
+```
+
+Output example:
+```
+[maintenance] Running at 2024-01-15T02:00:00Z
+MaintenanceResult{
+  table=streamforge.user_event_counts,
+  snapshotsExpired=2016,
+  manifestsRewritten=2016→4,
+  dataFiles=5760 (small=5760, 100.0%),
+  totalSize=8640.0 MB,
+  partitions=1,
+  duration=4821ms
+}
+[WARN] 1 partition(s) have small files. Run data-file compaction — see docs/ICEBERG_OPERATIONS.md §3.
+```
+
+---
+
+## 7. Manual runbook
+
+### Trigger maintenance immediately
+
+```bash
+docker compose exec iceberg-maintenance \
+  java -cp /opt/stream-processor/stream-processor-*.jar \
+  ai.streamforge.processor.maintenance.IcebergMaintenanceJob
+```
+
+### Expire snapshots only (skip manifest compaction)
+
+Use the Iceberg CLI directly against the table:
+
+```bash
+# Via Java (no Flink required)
+java -cp stream-processor-*.jar \
+  org.apache.iceberg.cli.Main expire-snapshots \
+  --catalog-impl org.apache.iceberg.hadoop.HadoopCatalog \
+  --warehouse s3a://streamforge/warehouse \
+  --table streamforge.user_event_counts \
+  --older-than "$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%S)"
+```
+
+### Roll back to a specific snapshot
+
+```bash
+# Find the snapshot ID to roll back to
+java -cp stream-processor-*.jar org.apache.iceberg.cli.Main \
+  list-snapshots --table streamforge.user_event_counts
+
+# Roll back
+java -cp stream-processor-*.jar org.apache.iceberg.cli.Main \
+  rollback-to-snapshot \
+  --table streamforge.user_event_counts \
+  --snapshot-id <SNAPSHOT_ID>
+```
+
+### List all partitions
+
+```bash
+java -cp stream-processor-*.jar org.apache.iceberg.cli.Main \
+  list-partitions \
+  --catalog-impl org.apache.iceberg.hadoop.HadoopCatalog \
+  --warehouse s3a://streamforge/warehouse \
+  --table streamforge.user_event_counts
+```
+
+---
+
+## 8. Querying the table
+
+### Flink SQL
+
+```sql
+CREATE CATALOG iceberg_catalog WITH (
+  'type'        = 'iceberg',
+  'catalog-type'= 'hadoop',
+  'warehouse'   = 's3a://streamforge/warehouse',
+  'fs.s3a.endpoint'          = 'http://minio:9000',
+  'fs.s3a.access.key'        = 'minioadmin',
+  'fs.s3a.secret.key'        = 'minioadmin',
+  'fs.s3a.path.style.access' = 'true'
+);
+
+USE CATALOG iceberg_catalog;
+
+-- Time-range scan (partition-pruned)
+SELECT   user_id, SUM(event_count) AS total_events
+FROM     streamforge.user_event_counts
+WHERE    event_date BETWEEN '2024-01-01' AND '2024-01-07'
+GROUP BY user_id
+ORDER BY total_events DESC
+LIMIT    10;
+
+-- Point-in-time read (snapshot travel)
+SELECT * FROM streamforge.user_event_counts
+FOR SYSTEM_TIME AS OF TIMESTAMP '2024-01-15 00:00:00';
+```
+
+### PyIceberg (Python analytics)
+
+```python
+from pyiceberg.catalog import load_catalog
+
+catalog = load_catalog("streamforge", **{
+    "type": "hadoop",
+    "warehouse": "s3a://streamforge/warehouse",
+})
+
+table = catalog.load_table("streamforge.user_event_counts")
+
+# Scan a single partition
+df = table.scan(
+    row_filter="event_date = '2024-01-15'"
+).to_arrow().to_pandas()
+
+print(df.groupby("user_id")["event_count"].sum().sort_values(ascending=False).head(10))
+```
+
+---
+
+## 9. Schema evolution
+
+Adding a new column to the Iceberg table is safe and backward compatible because
+Iceberg tracks field IDs, not column positions.
+
+### Adding an optional column
+
+1. Use field ID ≥ 6 (IDs 1–5 are reserved for the current schema).
+2. Update `IcebergSinkFactory.TABLE_SCHEMA` with the new field.
+3. Update `IcebergSinkFactory.toRowData()` to populate the new field at position N.
+4. The `ensureTable()` call will not re-create the table if it already exists.
+   Run an explicit schema update:
+
+```java
+Table table = catalog.loadTable(tableId);
+table.updateSchema()
+     .addColumn("new_column", Types.StringType.get())
+     .commit();
+```
+
+5. Old data files without the new column will return `null` for that field when read.
+   Declare the new field as `optional` in `TABLE_SCHEMA` to avoid validation errors.
+
+### Partition evolution (adding a second partition field)
+
+If you need to partition by an additional field (e.g., `user_id` for high-cardinality
+users), use Iceberg's partition evolution:
+
+```java
+table.updateSpec()
+     .addField(Expressions.bucket("user_id", 32))
+     .commit();
+```
+
+New writes use the new spec; old partitions remain readable under the old spec.
+Query planners handle mixed-spec tables transparently.
+
+> **Do not** rename the `event_date` partition column or change its transform — that
+> would break partition pruning for existing query plans and compaction scripts.

--- a/stream-processor/pom.xml
+++ b/stream-processor/pom.xml
@@ -152,6 +152,12 @@
                                 </filter>
                             </filters>
                             <transformers>
+                                <!--
+                                  Default main class: CdcUserEventCountJob (streaming pipeline).
+                                  To run the maintenance job:
+                                    java -cp stream-processor-*.jar \
+                                         ai.streamforge.processor.maintenance.IcebergMaintenanceJob
+                                -->
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <mainClass>ai.streamforge.processor.CdcUserEventCountJob</mainClass>
                                 </transformer>

--- a/stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/CdcUserEventCountJob.java
@@ -10,14 +10,17 @@ import ai.streamforge.processor.serialization.UserEventCountSerializationSchema;
 import ai.streamforge.processor.sink.IcebergSinkFactory;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.AggregateFunction;
+import org.apache.flink.api.common.restartstrategy.RestartStrategies;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
 import org.apache.flink.connector.kafka.sink.KafkaSink;
 import org.apache.flink.connector.kafka.source.KafkaSource;
 import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
 import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.CheckpointingMode;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+import org.apache.flink.streaming.api.environment.CheckpointConfig;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.functions.windowing.RichProcessWindowFunction;
 import org.apache.flink.streaming.api.windowing.assigners.TumblingEventTimeWindows;
@@ -28,33 +31,63 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Duration;
+import java.util.Properties;
 
 /**
- * Flink CDC aggregation job.
+ * Flink CDC aggregation job — primary entry point.
  *
- * Reads Debezium MySQL CDC events from Kafka, counts insert events per user
- * in tumbling event-time windows, and writes {@link UserEventCount} records
- * to an output Kafka topic.
+ * <p>Reads Debezium MySQL CDC events from Kafka, counts insert events per user
+ * in tumbling event-time windows, and writes {@link UserEventCount} to two sinks:
+ * <ol>
+ *   <li>Kafka ({@code user.event.counts}) — for real-time consumers.</li>
+ *   <li>Iceberg on MinIO — the primary analytics store, always enabled.</li>
+ * </ol>
  *
- * <p>Configuration via environment variables:
+ * <p>Iceberg is a first-class output. Disable it only for local dev by setting
+ * {@code ICEBERG_ENABLED=false}.
+ *
+ * <h2>Environment variables</h2>
+ *
+ * <h3>Kafka source / sink</h3>
  * <ul>
  *   <li>{@code KAFKA_BOOTSTRAP_SERVERS}  — default {@code localhost:9092}</li>
  *   <li>{@code KAFKA_SOURCE_TOPIC}       — default {@code cdc.streamforge.user_events}</li>
  *   <li>{@code KAFKA_SINK_TOPIC}         — default {@code user.event.counts}</li>
- *   <li>{@code KAFKA_DLQ_TOPIC}          — default {@code cdc.dead.letter}; set empty to disable</li>
+ *   <li>{@code KAFKA_DLQ_TOPIC}          — default {@code cdc.dead.letter}; blank to disable</li>
  *   <li>{@code KAFKA_CONSUMER_GROUP}     — default {@code flink-cdc-user-event-count}</li>
+ *   <li>{@code KAFKA_SINK_COMPRESSION}   — {@code none} (default), {@code snappy}, {@code lz4}, {@code zstd}</li>
+ *   <li>{@code KAFKA_SINK_BATCH_SIZE_BYTES} — default {@code 16384}</li>
+ *   <li>{@code KAFKA_SINK_LINGER_MS}     — default {@code 5}</li>
+ *   <li>{@code KAFKA_SINK_ACKS}          — default {@code all}</li>
+ * </ul>
+ *
+ * <h3>Window</h3>
+ * <ul>
  *   <li>{@code WINDOW_SIZE_SECONDS}      — default {@code 60}</li>
  *   <li>{@code OUT_OF_ORDERNESS_SECONDS} — default {@code 5}</li>
  * </ul>
  *
- * <p>Optional Apache Iceberg sink (set {@code ICEBERG_ENABLED=true} to activate):
+ * <h3>Flink parallelism &amp; checkpointing</h3>
  * <ul>
- *   <li>{@code ICEBERG_ENABLED}       — default {@code false}</li>
+ *   <li>{@code FLINK_PARALLELISM}              — default {@code -1} (cluster default)</li>
+ *   <li>{@code CHECKPOINT_INTERVAL_MS}         — default {@code 30000}</li>
+ *   <li>{@code CHECKPOINT_TIMEOUT_MS}          — default {@code 60000}</li>
+ *   <li>{@code CHECKPOINT_MIN_PAUSE_MS}        — default {@code 0}</li>
+ *   <li>{@code CHECKPOINT_MAX_CONCURRENT}      — default {@code 1}</li>
+ *   <li>{@code CHECKPOINT_MODE}                — {@code exactly_once} (default) or {@code at_least_once}</li>
+ *   <li>{@code CHECKPOINT_UNALIGNED}           — default {@code false}</li>
+ *   <li>{@code RESTART_ATTEMPTS}               — default {@code 3}</li>
+ *   <li>{@code RESTART_DELAY_MS}               — default {@code 10000}</li>
+ * </ul>
+ *
+ * <h3>Iceberg (primary analytics sink)</h3>
+ * <ul>
+ *   <li>{@code ICEBERG_ENABLED}       — default {@code true}; set {@code false} only for local dev</li>
  *   <li>{@code ICEBERG_CATALOG_TYPE}  — {@code hadoop} (default), {@code hive}, or {@code rest}</li>
- *   <li>{@code ICEBERG_WAREHOUSE}     — default {@code file:///tmp/iceberg-warehouse}</li>
+ *   <li>{@code ICEBERG_WAREHOUSE}     — default {@code s3a://streamforge/warehouse}</li>
  *   <li>{@code ICEBERG_DATABASE}      — default {@code streamforge}</li>
  *   <li>{@code ICEBERG_TABLE}         — default {@code user_event_counts}</li>
- *   <li>{@code ICEBERG_S3_ENDPOINT}   — S3/MinIO endpoint, e.g. {@code http://minio:9000}</li>
+ *   <li>{@code ICEBERG_S3_ENDPOINT}   — MinIO endpoint, e.g. {@code http://minio:9000}</li>
  *   <li>{@code ICEBERG_S3_ACCESS_KEY} — S3/MinIO access key</li>
  *   <li>{@code ICEBERG_S3_SECRET_KEY} — S3/MinIO secret key</li>
  * </ul>
@@ -64,6 +97,7 @@ public class CdcUserEventCountJob {
     private static final Logger LOG = LoggerFactory.getLogger(CdcUserEventCountJob.class);
 
     public static void main(String[] args) throws Exception {
+        // ── Kafka / window config ────────────────────────────────────────────
         String bootstrapServers      = env("KAFKA_BOOTSTRAP_SERVERS",  "localhost:9092");
         String sourceTopic           = env("KAFKA_SOURCE_TOPIC",       "cdc.streamforge.user_events");
         String sinkTopic             = env("KAFKA_SINK_TOPIC",         "user.event.counts");
@@ -72,12 +106,61 @@ public class CdcUserEventCountJob {
         long   windowSizeSeconds     = Long.parseLong(env("WINDOW_SIZE_SECONDS",      "60"));
         long   outOfOrdernessSeconds = Long.parseLong(env("OUT_OF_ORDERNESS_SECONDS", "5"));
 
-        LOG.info("Starting CdcUserEventCountJob: source={}, sink={}, dlq={}, window={}s",
-                sourceTopic, sinkTopic, dlqTopic.isBlank() ? "disabled" : dlqTopic, windowSizeSeconds);
+        // ── Flink parallelism ────────────────────────────────────────────────
+        int parallelism = Integer.parseInt(env("FLINK_PARALLELISM", "-1"));
 
+        // ── Checkpoint config ────────────────────────────────────────────────
+        long    ckptIntervalMs   = Long.parseLong(env("CHECKPOINT_INTERVAL_MS",    "30000"));
+        long    ckptTimeoutMs    = Long.parseLong(env("CHECKPOINT_TIMEOUT_MS",     "60000"));
+        long    ckptMinPauseMs   = Long.parseLong(env("CHECKPOINT_MIN_PAUSE_MS",   "0"));
+        int     maxConcurrentCkp = Integer.parseInt(env("CHECKPOINT_MAX_CONCURRENT", "1"));
+        boolean unaligned        = Boolean.parseBoolean(env("CHECKPOINT_UNALIGNED", "false"));
+        String  ckptModeStr      = env("CHECKPOINT_MODE", "exactly_once");
+        int     restartAttempts  = Integer.parseInt(env("RESTART_ATTEMPTS", "3"));
+        long    restartDelayMs   = Long.parseLong(env("RESTART_DELAY_MS",  "10000"));
+
+        // ── Iceberg (first-class sink, enabled by default) ───────────────────
+        boolean icebergEnabled = Boolean.parseBoolean(env("ICEBERG_ENABLED", "true"));
+        String  catalogType    = env("ICEBERG_CATALOG_TYPE",  "hadoop");
+        String  warehouse      = env("ICEBERG_WAREHOUSE",     "s3a://streamforge/warehouse");
+        String  database       = env("ICEBERG_DATABASE",      "streamforge");
+        String  icebergTable   = env("ICEBERG_TABLE",         "user_event_counts");
+        String  s3Endpoint     = env("ICEBERG_S3_ENDPOINT",   "");
+        String  s3AccessKey    = env("ICEBERG_S3_ACCESS_KEY", "");
+        String  s3SecretKey    = env("ICEBERG_S3_SECRET_KEY", "");
+
+        LOG.info("Starting CdcUserEventCountJob: source={}, sink={}, dlq={}, window={}s " +
+                 "parallelism={}, ckpt={}ms mode={} iceberg={}",
+                sourceTopic, sinkTopic, dlqTopic.isBlank() ? "disabled" : dlqTopic,
+                windowSizeSeconds,
+                parallelism < 0 ? "cluster-default" : parallelism,
+                ckptIntervalMs, ckptModeStr,
+                icebergEnabled ? warehouse + "/" + database + "." + icebergTable : "disabled");
+
+        // ── Flink environment ────────────────────────────────────────────────
         StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.enableCheckpointing(30_000);
 
+        if (parallelism > 0) {
+            env.setParallelism(parallelism);
+        }
+
+        CheckpointingMode ckptMode = "at_least_once".equalsIgnoreCase(ckptModeStr)
+                ? CheckpointingMode.AT_LEAST_ONCE
+                : CheckpointingMode.EXACTLY_ONCE;
+
+        env.enableCheckpointing(ckptIntervalMs, ckptMode);
+        CheckpointConfig ckptCfg = env.getCheckpointConfig();
+        ckptCfg.setCheckpointTimeout(ckptTimeoutMs);
+        ckptCfg.setMinPauseBetweenCheckpoints(ckptMinPauseMs);
+        ckptCfg.setMaxConcurrentCheckpoints(maxConcurrentCkp);
+        ckptCfg.enableUnalignedCheckpoints(unaligned);
+        ckptCfg.setExternalizedCheckpointCleanup(
+                CheckpointConfig.ExternalizedCheckpointCleanup.RETAIN_ON_CANCELLATION);
+
+        env.setRestartStrategy(
+                RestartStrategies.fixedDelayRestart(restartAttempts, restartDelayMs));
+
+        // ── Source ───────────────────────────────────────────────────────────
         KafkaSource<CdcEvent> source = KafkaSource.<CdcEvent>builder()
                 .setBootstrapServers(bootstrapServers)
                 .setTopics(sourceTopic)
@@ -100,9 +183,12 @@ public class CdcUserEventCountJob {
         DataStream<DeadLetterEvent> deadLetters =
                 filteredEvents.getSideOutput(SchemaEvolutionFilter.DLQ_TAG);
 
+        Properties kafkaSinkProps = buildKafkaSinkProps();
+
         if (!dlqTopic.isBlank()) {
             KafkaSink<DeadLetterEvent> dlqSink = KafkaSink.<DeadLetterEvent>builder()
                     .setBootstrapServers(bootstrapServers)
+                    .setKafkaProducerConfig(kafkaSinkProps)
                     .setRecordSerializer(
                             KafkaRecordSerializationSchema.<DeadLetterEvent>builder()
                                     .setTopic(dlqTopic)
@@ -123,32 +209,26 @@ public class CdcUserEventCountJob {
                 .aggregate(new EventCountAggregator(), new WindowMetadataFunction())
                 .name("Aggregate: count events per user per window");
 
-        KafkaSink<UserEventCount> sink = KafkaSink.<UserEventCount>builder()
+        // ── Kafka sink ───────────────────────────────────────────────────────
+        KafkaSink<UserEventCount> kafkaSink = KafkaSink.<UserEventCount>builder()
                 .setBootstrapServers(bootstrapServers)
+                .setKafkaProducerConfig(kafkaSinkProps)
                 .setRecordSerializer(
                         KafkaRecordSerializationSchema.<UserEventCount>builder()
                                 .setTopic(sinkTopic)
                                 .setValueSerializationSchema(new UserEventCountSerializationSchema())
                                 .build()
-                )
-                .build();
+                ).build();
 
-        counts.sinkTo(sink).name("Kafka Sink: " + sinkTopic);
+        counts.sinkTo(kafkaSink).name("Kafka Sink: " + sinkTopic);
 
-        // ── Optional Iceberg sink ────────────────────────────────────────────
-        if (Boolean.parseBoolean(env("ICEBERG_ENABLED", "false"))) {
-            String catalogType  = env("ICEBERG_CATALOG_TYPE",  "hadoop");
-            String warehouse    = env("ICEBERG_WAREHOUSE",     "file:///tmp/iceberg-warehouse");
-            String database     = env("ICEBERG_DATABASE",      "streamforge");
-            String icebergTable = env("ICEBERG_TABLE",         "user_event_counts");
-            String s3Endpoint   = env("ICEBERG_S3_ENDPOINT",   "");
-            String s3AccessKey  = env("ICEBERG_S3_ACCESS_KEY", "");
-            String s3SecretKey  = env("ICEBERG_S3_SECRET_KEY", "");
-
-            LOG.info("Iceberg sink enabled: catalog={}, warehouse={}, table={}.{}",
-                    catalogType, warehouse, database, icebergTable);
-            IcebergSinkFactory.attach(counts, catalogType, warehouse, database, icebergTable,
-                    s3Endpoint, s3AccessKey, s3SecretKey);
+        // ── Iceberg sink (first-class analytics store) ───────────────────────
+        if (icebergEnabled) {
+            IcebergSinkFactory.attach(counts, catalogType, warehouse, database,
+                    icebergTable, s3Endpoint, s3AccessKey, s3SecretKey);
+        } else {
+            LOG.warn("Iceberg sink disabled via ICEBERG_ENABLED=false. " +
+                     "Set ICEBERG_ENABLED=true (the default) for production deployments.");
         }
 
         env.execute("CdcUserEventCountJob");
@@ -156,7 +236,6 @@ public class CdcUserEventCountJob {
 
     // ── Aggregation functions ────────────────────────────────────────────────
 
-    /** Incrementally accumulates a running event count. */
     static class EventCountAggregator implements AggregateFunction<CdcEvent, Long, Long> {
         @Override public Long createAccumulator()           { return 0L; }
         @Override public Long add(CdcEvent e, Long acc)     { return acc + 1; }
@@ -166,10 +245,10 @@ public class CdcUserEventCountJob {
 
     /**
      * Attaches window boundaries and the keyed userId to the final count.
-     * Also increments two Flink metrics:
+     * Metrics:
      * <ul>
-     *   <li>{@code windows_fired_total} — one per window that produces output</li>
-     *   <li>{@code window_counts_emitted_total} — sum of all event counts across windows</li>
+     *   <li>{@code windows_fired_total}</li>
+     *   <li>{@code window_counts_emitted_total}</li>
      * </ul>
      */
     static class WindowMetadataFunction
@@ -180,20 +259,18 @@ public class CdcUserEventCountJob {
 
         @Override
         public void open(Configuration parameters) {
-            windowsFired   = getRuntimeContext().getMetricGroup().counter("windows_fired_total");
-            countsEmitted  = getRuntimeContext().getMetricGroup().counter("window_counts_emitted_total");
+            windowsFired  = getRuntimeContext().getMetricGroup().counter("windows_fired_total");
+            countsEmitted = getRuntimeContext().getMetricGroup().counter("window_counts_emitted_total");
         }
 
         @Override
-        public void process(
-                String userId,
-                Context ctx,
-                Iterable<Long> counts,
-                Collector<UserEventCount> out) {
+        public void process(String userId, Context ctx, Iterable<Long> counts,
+                            Collector<UserEventCount> out) {
             long count = counts.iterator().next();
             windowsFired.inc();
             countsEmitted.inc(count);
-            out.collect(new UserEventCount(userId, count, ctx.window().getStart(), ctx.window().getEnd()));
+            out.collect(new UserEventCount(
+                    userId, count, ctx.window().getStart(), ctx.window().getEnd()));
         }
     }
 
@@ -202,5 +279,18 @@ public class CdcUserEventCountJob {
     private static String env(String name, String defaultValue) {
         String v = System.getenv(name);
         return (v != null && !v.isBlank()) ? v : defaultValue;
+    }
+
+    private static Properties buildKafkaSinkProps() {
+        Properties props = new Properties();
+        props.setProperty("batch.size",    env("KAFKA_SINK_BATCH_SIZE_BYTES",    "16384"));
+        props.setProperty("linger.ms",     env("KAFKA_SINK_LINGER_MS",           "5"));
+        props.setProperty("buffer.memory", env("KAFKA_SINK_BUFFER_MEMORY_BYTES", "33554432"));
+        props.setProperty("acks",          env("KAFKA_SINK_ACKS",                "all"));
+        String compression = env("KAFKA_SINK_COMPRESSION", "none");
+        if (!"none".equalsIgnoreCase(compression)) {
+            props.setProperty("compression.type", compression);
+        }
+        return props;
     }
 }

--- a/stream-processor/src/main/java/ai/streamforge/processor/maintenance/IcebergMaintenanceJob.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/maintenance/IcebergMaintenanceJob.java
@@ -1,0 +1,252 @@
+package ai.streamforge.processor.maintenance;
+
+import ai.streamforge.processor.sink.IcebergSinkFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.RewriteManifests;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.CatalogLoader;
+import org.apache.iceberg.io.CloseableIterable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Standalone table-maintenance job for the StreamForge Iceberg analytics store.
+ *
+ * <p>Runs three ordered phases on each execution:
+ * <ol>
+ *   <li><b>Snapshot expiry</b> — removes snapshots older than {@code SNAPSHOT_MAX_AGE_HOURS}
+ *       while retaining at least {@code SNAPSHOT_RETAIN_LAST} recent snapshots.
+ *       Expired snapshot files (orphan manifests, position-delete files) are deleted from
+ *       object storage immediately.</li>
+ *   <li><b>Manifest compaction</b> — rewrites fragmented manifests into fewer, larger ones.
+ *       Each Flink checkpoint appends one manifest entry; after hours of streaming this
+ *       inflates the manifest list and slows down table scans.</li>
+ *   <li><b>Data-file health report</b> — scans all live data files and reports which
+ *       partitions contain small files (below {@code COMPACT_SMALL_FILE_THRESHOLD_BYTES}).
+ *       Actual data-file compaction requires a Flink batch job; see
+ *       {@code docs/ICEBERG_OPERATIONS.md} for the command.</li>
+ * </ol>
+ *
+ * <h2>Running</h2>
+ * <pre>
+ *   # Phase 1 + 2 + report only (no data-file compaction):
+ *   java -cp stream-processor-*.jar \
+ *        ai.streamforge.processor.maintenance.IcebergMaintenanceJob
+ *
+ *   # Scheduled via docker-compose iceberg-maintenance service:
+ *   # See deploy/cdc-flink-minio-demo/docker-compose.yml
+ * </pre>
+ *
+ * <h2>Environment variables</h2>
+ * <ul>
+ *   <li>{@code ICEBERG_CATALOG_TYPE}              — {@code hadoop} (default), {@code hive}, {@code rest}</li>
+ *   <li>{@code ICEBERG_WAREHOUSE}                 — default {@code s3a://streamforge/warehouse}</li>
+ *   <li>{@code ICEBERG_DATABASE}                  — default {@code streamforge}</li>
+ *   <li>{@code ICEBERG_TABLE}                     — default {@code user_event_counts}</li>
+ *   <li>{@code ICEBERG_S3_ENDPOINT}               — MinIO endpoint, e.g. {@code http://minio:9000}</li>
+ *   <li>{@code ICEBERG_S3_ACCESS_KEY}             — S3/MinIO access key</li>
+ *   <li>{@code ICEBERG_S3_SECRET_KEY}             — S3/MinIO secret key</li>
+ *   <li>{@code SNAPSHOT_MAX_AGE_HOURS}            — expire snapshots older than N hours,
+ *       default {@code 168} (7 days)</li>
+ *   <li>{@code SNAPSHOT_RETAIN_LAST}              — always keep at least this many recent
+ *       snapshots regardless of age, default {@code 10}</li>
+ *   <li>{@code COMPACT_SMALL_FILE_THRESHOLD_BYTES} — files smaller than this are flagged
+ *       as candidates for data-file compaction, default {@code 67108864} (64 MB)</li>
+ *   <li>{@code DRY_RUN}                           — {@code true} to report without
+ *       committing any changes, default {@code false}</li>
+ * </ul>
+ */
+public class IcebergMaintenanceJob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(IcebergMaintenanceJob.class);
+
+    public static void main(String[] args) {
+        MaintenanceResult result = run();
+        System.out.println(result);
+        if (result.smallDataFiles > 0) {
+            System.out.printf(
+                "[WARN] %d partition(s) have small files. Run data-file compaction — " +
+                "see docs/ICEBERG_OPERATIONS.md §3.%n", result.partitionsScanned);
+        }
+    }
+
+    /** Executes all maintenance phases and returns a summary. */
+    public static MaintenanceResult run() {
+        String catalogType  = env("ICEBERG_CATALOG_TYPE",  "hadoop");
+        String warehouse    = env("ICEBERG_WAREHOUSE",     "s3a://streamforge/warehouse");
+        String database     = env("ICEBERG_DATABASE",      "streamforge");
+        String tableName    = env("ICEBERG_TABLE",         "user_event_counts");
+        String s3Endpoint   = env("ICEBERG_S3_ENDPOINT",   "");
+        String s3AccessKey  = env("ICEBERG_S3_ACCESS_KEY", "");
+        String s3SecretKey  = env("ICEBERG_S3_SECRET_KEY", "");
+
+        long    maxAgeHours     = Long.parseLong(env("SNAPSHOT_MAX_AGE_HOURS",             "168"));
+        int     retainLast      = Integer.parseInt(env("SNAPSHOT_RETAIN_LAST",             "10"));
+        long    smallThreshold  = Long.parseLong(env("COMPACT_SMALL_FILE_THRESHOLD_BYTES", "67108864"));
+        boolean dryRun          = Boolean.parseBoolean(env("DRY_RUN",                      "false"));
+
+        String tableId = database + "." + tableName;
+
+        LOG.info("IcebergMaintenanceJob starting: table={}, maxAgeHours={}, retainLast={}, " +
+                 "smallThreshold={}MB, dryRun={}",
+                tableId, maxAgeHours, retainLast, smallThreshold / 1024 / 1024, dryRun);
+
+        long startMs = System.currentTimeMillis();
+
+        Configuration hadoopConf = IcebergSinkFactory.buildHadoopConf(
+                s3Endpoint, s3AccessKey, s3SecretKey);
+        CatalogLoader catalogLoader = IcebergSinkFactory.buildCatalogLoader(
+                catalogType, warehouse, hadoopConf);
+
+        Catalog catalog = catalogLoader.loadCatalog();
+        TableIdentifier identifier = TableIdentifier.of(database, tableName);
+
+        if (!catalog.tableExists(identifier)) {
+            LOG.warn("Table {} does not exist — nothing to maintain.", tableId);
+            return new MaintenanceResult(tableId, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    System.currentTimeMillis() - startMs);
+        }
+
+        Table table = catalog.loadTable(identifier);
+
+        // ── Phase 1: Snapshot expiry ─────────────────────────────────────────
+        long expiryBeforeMs = System.currentTimeMillis()
+                - TimeUnit.HOURS.toMillis(maxAgeHours);
+
+        int   snapshotsExpiredCount  = 0;
+        long  deletedDataFiles       = 0;
+        long  deletedManifestFiles   = 0;
+
+        List<Long> snapshotIds = new ArrayList<>();
+        for (Snapshot s : table.snapshots()) {
+            snapshotIds.add(s.snapshotId());
+        }
+        int totalSnapshots = snapshotIds.size();
+
+        if (dryRun) {
+            // Count what would be expired without committing
+            for (Snapshot s : table.snapshots()) {
+                if (s.timestampMillis() < expiryBeforeMs
+                        && totalSnapshots - snapshotsExpiredCount > retainLast) {
+                    snapshotsExpiredCount++;
+                }
+            }
+            LOG.info("[DRY RUN] Would expire {} snapshot(s)", snapshotsExpiredCount);
+        } else {
+            List<Long> deletedDataFilesList   = new ArrayList<>();
+            List<Long> deletedManifestFilesList = new ArrayList<>();
+
+            table.expireSnapshots()
+                    .expireOlderThan(expiryBeforeMs)
+                    .retainLast(retainLast)
+                    .cleanExpiredFiles(true)
+                    .deleteWith(path -> {
+                        // Track deleted files by extension
+                        if (path.endsWith(".avro")) {
+                            deletedManifestFilesList.add(1L);
+                        } else {
+                            deletedDataFilesList.add(1L);
+                        }
+                    })
+                    .commit();
+
+            deletedDataFiles     = deletedDataFilesList.size();
+            deletedManifestFiles = deletedManifestFilesList.size();
+
+            // Count how many snapshots remain vs. before
+            int remaining = 0;
+            for (Snapshot ignored : table.snapshots()) remaining++;
+            snapshotsExpiredCount = totalSnapshots - remaining;
+
+            LOG.info("Phase 1 complete: expired {} snapshots, deleted {} data files, " +
+                     "{} manifest files",
+                    snapshotsExpiredCount, deletedDataFiles, deletedManifestFiles);
+        }
+
+        // ── Phase 2: Manifest compaction ─────────────────────────────────────
+        int manifestsBefore = 0;
+        int manifestsAfter  = 0;
+
+        Snapshot currentSnapshot = table.currentSnapshot();
+        if (currentSnapshot != null) {
+            manifestsBefore = currentSnapshot.allManifests(table.io()).size();
+        }
+
+        if (manifestsBefore > 1) {
+            if (dryRun) {
+                LOG.info("[DRY RUN] Would compact {} manifests", manifestsBefore);
+                manifestsAfter = manifestsBefore;
+            } else {
+                RewriteManifests rewrite = table.rewriteManifests();
+                rewrite.commit();
+                currentSnapshot = table.currentSnapshot();
+                manifestsAfter = currentSnapshot != null
+                        ? currentSnapshot.allManifests(table.io()).size()
+                        : 0;
+                LOG.info("Phase 2 complete: manifests {} → {}", manifestsBefore, manifestsAfter);
+            }
+        } else {
+            manifestsAfter = manifestsBefore;
+            LOG.info("Phase 2 skipped: only {} manifest(s), no compaction needed", manifestsBefore);
+        }
+
+        // ── Phase 3: Data-file health scan ────────────────────────────────────
+        long totalFiles      = 0;
+        long smallFiles      = 0;
+        long totalSizeBytes  = 0;
+        int  partitions      = 0;
+
+        String lastPartition = null;
+        try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+            for (FileScanTask task : tasks) {
+                DataFile file = task.file();
+                String partition = file.partition().toString();
+                if (!partition.equals(lastPartition)) {
+                    partitions++;
+                    lastPartition = partition;
+                }
+                totalFiles++;
+                totalSizeBytes += file.fileSizeInBytes();
+                if (file.fileSizeInBytes() < smallThreshold) {
+                    smallFiles++;
+                }
+            }
+        } catch (Exception e) {
+            LOG.warn("Phase 3: could not scan data files — {}", e.getMessage());
+        }
+
+        LOG.info("Phase 3 complete: {} files ({} small) across {} partition(s), total {:.1f} MB",
+                totalFiles, smallFiles, partitions, totalSizeBytes / 1e6);
+
+        MaintenanceResult result = new MaintenanceResult(
+                tableId,
+                snapshotsExpiredCount,
+                deletedDataFiles,
+                deletedManifestFiles,
+                manifestsBefore,
+                manifestsAfter,
+                totalFiles,
+                smallFiles,
+                totalSizeBytes,
+                partitions,
+                System.currentTimeMillis() - startMs);
+
+        LOG.info("IcebergMaintenanceJob complete: {}", result);
+        return result;
+    }
+
+    private static String env(String name, String defaultValue) {
+        String v = System.getenv(name);
+        return (v != null && !v.isBlank()) ? v : defaultValue;
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/maintenance/MaintenanceResult.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/maintenance/MaintenanceResult.java
@@ -1,0 +1,66 @@
+package ai.streamforge.processor.maintenance;
+
+/** Summary produced by a single run of {@link IcebergMaintenanceJob}. */
+public class MaintenanceResult {
+
+    public final String  tableIdentifier;
+
+    // Snapshot expiry
+    public final int     snapshotsExpired;
+    public final long    dataFilesDeletedByExpiry;
+    public final long    manifestFilesDeletedByExpiry;
+
+    // Manifest compaction
+    public final int     manifestsBeforeRewrite;
+    public final int     manifestsAfterRewrite;
+
+    // Data file health (informational — compaction is a separate Flink batch run)
+    public final long    totalDataFiles;
+    public final long    smallDataFiles;        // below COMPACT_SMALL_FILE_THRESHOLD_BYTES
+    public final long    totalDataSizeBytes;
+    public final int     partitionsScanned;
+
+    public final long    durationMs;
+
+    public MaintenanceResult(
+            String tableIdentifier,
+            int snapshotsExpired,
+            long dataFilesDeletedByExpiry,
+            long manifestFilesDeletedByExpiry,
+            int manifestsBeforeRewrite,
+            int manifestsAfterRewrite,
+            long totalDataFiles,
+            long smallDataFiles,
+            long totalDataSizeBytes,
+            int partitionsScanned,
+            long durationMs) {
+        this.tableIdentifier             = tableIdentifier;
+        this.snapshotsExpired            = snapshotsExpired;
+        this.dataFilesDeletedByExpiry    = dataFilesDeletedByExpiry;
+        this.manifestFilesDeletedByExpiry = manifestFilesDeletedByExpiry;
+        this.manifestsBeforeRewrite      = manifestsBeforeRewrite;
+        this.manifestsAfterRewrite       = manifestsAfterRewrite;
+        this.totalDataFiles              = totalDataFiles;
+        this.smallDataFiles              = smallDataFiles;
+        this.totalDataSizeBytes          = totalDataSizeBytes;
+        this.partitionsScanned           = partitionsScanned;
+        this.durationMs                  = durationMs;
+    }
+
+    @Override
+    public String toString() {
+        return String.format(
+            "MaintenanceResult{table=%s, snapshotsExpired=%d, " +
+            "manifestsRewritten=%d→%d, " +
+            "dataFiles=%d (small=%d, %.1f%%), totalSize=%.1f MB, " +
+            "partitions=%d, duration=%dms}",
+            tableIdentifier,
+            snapshotsExpired,
+            manifestsBeforeRewrite, manifestsAfterRewrite,
+            totalDataFiles, smallDataFiles,
+            totalDataFiles > 0 ? 100.0 * smallDataFiles / totalDataFiles : 0.0,
+            totalDataSizeBytes / 1e6,
+            partitionsScanned,
+            durationMs);
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/sink/IcebergSinkFactory.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/sink/IcebergSinkFactory.java
@@ -3,13 +3,14 @@ package ai.streamforge.processor.sink;
 import ai.streamforge.processor.model.UserEventCount;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
-import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -20,30 +21,87 @@ import org.apache.iceberg.types.Types;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Builds and attaches an Apache Iceberg sink to a {@link UserEventCount} stream.
+ * Builds and attaches the primary Apache Iceberg sink to a {@link UserEventCount} stream.
  *
- * <p>Supported catalog types: {@code hadoop} (default), {@code hive}, {@code rest}.
- * For MinIO / S3-compatible storage set the {@code ICEBERG_S3_*} environment variables
- * so the Hadoop S3A filesystem is configured automatically.
+ * <h2>Schema</h2>
+ * <pre>
+ *   user_id         STRING  NOT NULL
+ *   event_count     LONG    NOT NULL
+ *   window_start_ms LONG    NOT NULL
+ *   window_end_ms   LONG    NOT NULL
+ *   event_date      STRING  NOT NULL   -- YYYY-MM-DD, derived from window_start_ms (UTC)
+ * </pre>
+ *
+ * <h2>Partitioning</h2>
+ * The table is partitioned by {@code identity(event_date)}, which places all records
+ * for a given calendar day (UTC) in the same S3 directory. This gives:
+ * <ul>
+ *   <li>Efficient time-range queries — planners prune entire day directories.</li>
+ *   <li>Predictable compaction scope — each day's files form an independent group.</li>
+ *   <li>Safe late-data handling — late events land in the correct day partition
+ *       without touching already-compacted older partitions.</li>
+ * </ul>
+ *
+ * <h2>Catalog types</h2>
+ * {@code hadoop} (default), {@code hive}, {@code rest}.
+ * For MinIO / S3-compatible storage set the {@code ICEBERG_S3_*} environment variables.
+ *
+ * <h2>Tuning knobs (environment variables)</h2>
+ * <ul>
+ *   <li>{@code ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES} — target data-file size before rolling,
+ *       default {@code 134217728} (128 MB).</li>
+ *   <li>{@code ICEBERG_WRITE_FORMAT}                 — {@code parquet} (default), {@code avro},
+ *       or {@code orc}.</li>
+ *   <li>{@code ICEBERG_WRITE_PARQUET_ROW_GROUP_SIZE_BYTES} — Parquet row-group size,
+ *       default {@code 134217728} (128 MB).</li>
+ *   <li>{@code ICEBERG_WRITE_PARQUET_PAGE_SIZE_BYTES} — Parquet page size,
+ *       default {@code 1048576} (1 MB).</li>
+ *   <li>{@code ICEBERG_WRITE_PARALLELISM}            — sink operator parallelism,
+ *       default {@code -1} (inherit from env).</li>
+ *   <li>{@code ICEBERG_S3_MULTIPART_SIZE}            — S3A multipart part size,
+ *       default {@code 67108864} (64 MB).</li>
+ *   <li>{@code ICEBERG_S3_MULTIPART_THRESHOLD}       — multipart upload threshold,
+ *       default {@code 67108864} (64 MB).</li>
+ *   <li>{@code ICEBERG_S3_UPLOAD_THREADS}            — parallel S3A upload threads,
+ *       default {@code 10}.</li>
+ * </ul>
  */
 public class IcebergSinkFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(IcebergSinkFactory.class);
 
-    static final Schema TABLE_SCHEMA = new Schema(
+    /**
+     * Table schema. Field IDs are stable — adding new optional fields at the end
+     * is backward compatible with existing data files.
+     */
+    public static final Schema TABLE_SCHEMA = new Schema(
             Types.NestedField.required(1, "user_id",         Types.StringType.get()),
             Types.NestedField.required(2, "event_count",     Types.LongType.get()),
             Types.NestedField.required(3, "window_start_ms", Types.LongType.get()),
-            Types.NestedField.required(4, "window_end_ms",   Types.LongType.get())
+            Types.NestedField.required(4, "window_end_ms",   Types.LongType.get()),
+            Types.NestedField.required(5, "event_date",      Types.StringType.get())
     );
 
     /**
-     * Converts {@code stream} to Iceberg {@link RowData} and appends it to the
-     * specified Iceberg table, creating the namespace and table if absent.
+     * Partition by calendar day (UTC) derived from {@code window_start_ms}.
+     * Using identity transform keeps partition pruning exact with no transform overhead.
+     */
+    public static final PartitionSpec PARTITION_SPEC =
+            PartitionSpec.builderFor(TABLE_SCHEMA)
+                    .identity("event_date")
+                    .build();
+
+    // ── Public entry point ───────────────────────────────────────────────────
+
+    /**
+     * Maps {@code stream} to Iceberg {@link RowData}, ensures the partitioned table
+     * exists, and attaches a {@link FlinkSink} in append mode.
      */
     public static void attach(
             DataStream<UserEventCount> stream,
@@ -64,27 +122,53 @@ public class IcebergSinkFactory {
         TableLoader tableLoader = TableLoader.fromCatalog(catalogLoader, tableId);
 
         DataStream<RowData> rowData = stream
-                .map((MapFunction<UserEventCount, RowData>) e -> {
-                    GenericRowData row = new GenericRowData(4);
-                    row.setField(0, StringData.fromString(e.userId));
-                    row.setField(1, e.count);
-                    row.setField(2, e.windowStartMs);
-                    row.setField(3, e.windowEndMs);
-                    return row;
-                })
+                .map((MapFunction<UserEventCount, RowData>) IcebergSinkFactory::toRowData)
                 .returns(TypeInformation.of(RowData.class))
                 .name("Map to Iceberg RowData");
 
-        FlinkSink.forRowData(rowData)
-                .tableLoader(tableLoader)
-                .append()
-                .name("Iceberg Sink: " + database + "." + tableName);
+        Map<String, String> writeProps = buildWriteProperties();
+        int writePar = writeParallelism();
 
-        LOG.info("Iceberg sink attached: catalog={}, warehouse={}, table={}.{}",
-                catalogType, warehouse, database, tableName);
+        FlinkSink.Builder sinkBuilder = FlinkSink.forRowData(rowData)
+                .tableLoader(tableLoader)
+                .setAll(writeProps)
+                .append();
+
+        if (writePar > 0) {
+            sinkBuilder.writeParallelism(writePar);
+        }
+
+        sinkBuilder.name("Iceberg Sink: " + database + "." + tableName);
+
+        LOG.info("Iceberg sink attached: catalog={}, warehouse={}, table={}.{}, " +
+                 "partition=identity(event_date), writeProps={}",
+                catalogType, warehouse, database, tableName, writeProps);
     }
 
-    private static CatalogLoader buildCatalogLoader(
+    // ── RowData mapping ──────────────────────────────────────────────────────
+
+    /** Converts a {@link UserEventCount} to the 5-field Iceberg {@link RowData}. */
+    static RowData toRowData(UserEventCount e) {
+        GenericRowData row = new GenericRowData(5);
+        row.setField(0, StringData.fromString(e.userId));
+        row.setField(1, e.count);
+        row.setField(2, e.windowStartMs);
+        row.setField(3, e.windowEndMs);
+        row.setField(4, StringData.fromString(toEventDate(e.windowStartMs)));
+        return row;
+    }
+
+    /** Returns a {@code YYYY-MM-DD} string (UTC) for the given epoch-millisecond timestamp. */
+    static String toEventDate(long epochMs) {
+        return Instant.ofEpochMilli(epochMs)
+                .atZone(ZoneOffset.UTC)
+                .toLocalDate()
+                .toString();
+    }
+
+    // ── Catalog / table helpers ──────────────────────────────────────────────
+
+    static CatalogLoader buildCatalogLoader(
             String catalogType, String warehouse, Configuration hadoopConf) {
         Map<String, String> props = new HashMap<>();
         props.put("warehouse", warehouse);
@@ -101,7 +185,7 @@ public class IcebergSinkFactory {
         };
     }
 
-    private static void ensureTable(
+    static void ensureTable(
             CatalogLoader catalogLoader, TableIdentifier tableId, String database) {
         Catalog catalog = catalogLoader.loadCatalog();
         Namespace ns = Namespace.of(database);
@@ -109,12 +193,42 @@ public class IcebergSinkFactory {
             catalog.createNamespace(ns);
         }
         if (!catalog.tableExists(tableId)) {
-            catalog.createTable(tableId, TABLE_SCHEMA, PartitionSpec.unpartitioned());
-            LOG.info("Created Iceberg table {}", tableId);
+            Table table = catalog.createTable(tableId, TABLE_SCHEMA, PARTITION_SPEC);
+            // Set default write properties on the newly created table
+            table.updateProperties()
+                    .set("write.target-file-size-bytes",
+                            senv("ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES", "134217728"))
+                    .set("write.format.default",
+                            senv("ICEBERG_WRITE_FORMAT", "parquet"))
+                    .commit();
+            LOG.info("Created partitioned Iceberg table {} with partition spec {}",
+                    tableId, PARTITION_SPEC);
         }
     }
 
-    private static Configuration buildHadoopConf(
+    // ── Write properties ─────────────────────────────────────────────────────
+
+    static Map<String, String> buildWriteProperties() {
+        Map<String, String> props = new HashMap<>();
+        props.put("write.target-file-size-bytes",
+                senv("ICEBERG_WRITE_TARGET_FILE_SIZE_BYTES", "134217728"));
+        props.put("write.format.default",
+                senv("ICEBERG_WRITE_FORMAT", "parquet"));
+        props.put("write.parquet.row-group-size-bytes",
+                senv("ICEBERG_WRITE_PARQUET_ROW_GROUP_SIZE_BYTES", "134217728"));
+        props.put("write.parquet.page-size-bytes",
+                senv("ICEBERG_WRITE_PARQUET_PAGE_SIZE_BYTES", "1048576"));
+        return props;
+    }
+
+    static int writeParallelism() {
+        String v = System.getenv("ICEBERG_WRITE_PARALLELISM");
+        return (v != null && !v.isBlank()) ? Integer.parseInt(v) : -1;
+    }
+
+    // ── Hadoop / S3A config ──────────────────────────────────────────────────
+
+    static Configuration buildHadoopConf(
             String s3Endpoint, String s3AccessKey, String s3SecretKey) {
         Configuration conf = new Configuration();
         if (s3Endpoint != null && !s3Endpoint.isBlank()) {
@@ -123,7 +237,18 @@ public class IcebergSinkFactory {
             conf.set("fs.s3a.secret.key",        s3SecretKey != null ? s3SecretKey : "");
             conf.set("fs.s3a.path.style.access", "true");
             conf.set("fs.s3a.impl",              "org.apache.hadoop.fs.s3a.S3AFileSystem");
+            conf.set("fs.s3a.multipart.size",
+                    senv("ICEBERG_S3_MULTIPART_SIZE", "67108864"));
+            conf.set("fs.s3a.multipart.threshold",
+                    senv("ICEBERG_S3_MULTIPART_THRESHOLD", "67108864"));
+            conf.set("fs.s3a.threads.max",
+                    senv("ICEBERG_S3_UPLOAD_THREADS", "10"));
         }
         return conf;
+    }
+
+    private static String senv(String name, String defaultValue) {
+        String v = System.getenv(name);
+        return (v != null && !v.isBlank()) ? v : defaultValue;
     }
 }

--- a/stream-processor/src/test/java/ai/streamforge/processor/sink/IcebergSinkFactoryTest.java
+++ b/stream-processor/src/test/java/ai/streamforge/processor/sink/IcebergSinkFactoryTest.java
@@ -1,0 +1,194 @@
+package ai.streamforge.processor.sink;
+
+import ai.streamforge.processor.model.UserEventCount;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.iceberg.PartitionField;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link IcebergSinkFactory} — schema shape, partition spec,
+ * RowData mapping, and date derivation.
+ *
+ * No Flink or MinIO runtime required; all assertions operate on static methods
+ * and pure value logic.
+ */
+class IcebergSinkFactoryTest {
+
+    // ── Schema ────────────────────────────────────────────────────────────────
+
+    @Test
+    void schema_hasFiveFields() {
+        Schema schema = IcebergSinkFactory.TABLE_SCHEMA;
+        assertEquals(5, schema.columns().size());
+    }
+
+    @Test
+    void schema_fieldIds_areStable() {
+        Schema schema = IcebergSinkFactory.TABLE_SCHEMA;
+        assertEquals(1, schema.findField("user_id").fieldId());
+        assertEquals(2, schema.findField("event_count").fieldId());
+        assertEquals(3, schema.findField("window_start_ms").fieldId());
+        assertEquals(4, schema.findField("window_end_ms").fieldId());
+        assertEquals(5, schema.findField("event_date").fieldId());
+    }
+
+    @Test
+    void schema_allFieldsRequired() {
+        IcebergSinkFactory.TABLE_SCHEMA.columns()
+                .forEach(f -> assertTrue(f.isRequired(),
+                        "Expected " + f.name() + " to be required"));
+    }
+
+    @Test
+    void schema_eventDate_isString() {
+        Types.NestedField field = IcebergSinkFactory.TABLE_SCHEMA.findField("event_date");
+        assertNotNull(field);
+        assertEquals(Types.StringType.get(), field.type());
+    }
+
+    // ── Partition spec ────────────────────────────────────────────────────────
+
+    @Test
+    void partitionSpec_hasOneField() {
+        PartitionSpec spec = IcebergSinkFactory.PARTITION_SPEC;
+        assertEquals(1, spec.fields().size());
+    }
+
+    @Test
+    void partitionSpec_isIdentityOnEventDate() {
+        PartitionSpec spec = IcebergSinkFactory.PARTITION_SPEC;
+        PartitionField pf  = spec.fields().get(0);
+        assertEquals("event_date", pf.name());
+        assertEquals(Transforms.identity(), pf.transform());
+    }
+
+    @Test
+    void partitionSpec_sourceFieldId_matchesSchemaEventDate() {
+        PartitionSpec spec  = IcebergSinkFactory.PARTITION_SPEC;
+        int specSourceId    = spec.fields().get(0).sourceId();
+        int schemaFieldId   = IcebergSinkFactory.TABLE_SCHEMA.findField("event_date").fieldId();
+        assertEquals(schemaFieldId, specSourceId);
+    }
+
+    // ── toEventDate ───────────────────────────────────────────────────────────
+
+    @Test
+    void toEventDate_returnsIsoDate() {
+        // 2024-01-15 00:00:00 UTC in epoch-ms
+        long epochMs = LocalDate.of(2024, 1, 15)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant()
+                .toEpochMilli();
+        assertEquals("2024-01-15", IcebergSinkFactory.toEventDate(epochMs));
+    }
+
+    @Test
+    void toEventDate_justBeforeMidnight_staysInSameDay() {
+        // 2024-03-10 23:59:59.999 UTC
+        long epochMs = LocalDate.of(2024, 3, 10)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant()
+                .toEpochMilli() + 86_399_999L;
+        assertEquals("2024-03-10", IcebergSinkFactory.toEventDate(epochMs));
+    }
+
+    @Test
+    void toEventDate_atMidnight_advancesToNextDay() {
+        // Exactly 2024-03-11 00:00:00.000 UTC
+        long epochMs = LocalDate.of(2024, 3, 11)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant()
+                .toEpochMilli();
+        assertEquals("2024-03-11", IcebergSinkFactory.toEventDate(epochMs));
+    }
+
+    // ── toRowData ─────────────────────────────────────────────────────────────
+
+    @Test
+    void toRowData_hasFiveFields() {
+        RowData row = IcebergSinkFactory.toRowData(sampleEvent());
+        // GenericRowData.getArity() is the field count
+        assertEquals(5, row.getArity());
+    }
+
+    @Test
+    void toRowData_userId_isCorrect() {
+        RowData row = IcebergSinkFactory.toRowData(sampleEvent());
+        assertEquals(StringData.fromString("user-42"), row.getString(0));
+    }
+
+    @Test
+    void toRowData_eventCount_isCorrect() {
+        RowData row = IcebergSinkFactory.toRowData(sampleEvent());
+        assertEquals(7L, row.getLong(1));
+    }
+
+    @Test
+    void toRowData_windowStartMs_isCorrect() {
+        UserEventCount e = sampleEvent();
+        RowData row = IcebergSinkFactory.toRowData(e);
+        assertEquals(e.windowStartMs, row.getLong(2));
+    }
+
+    @Test
+    void toRowData_windowEndMs_isCorrect() {
+        UserEventCount e = sampleEvent();
+        RowData row = IcebergSinkFactory.toRowData(e);
+        assertEquals(e.windowEndMs, row.getLong(3));
+    }
+
+    @Test
+    void toRowData_eventDate_matchesToEventDate() {
+        UserEventCount e = sampleEvent();
+        RowData row = IcebergSinkFactory.toRowData(e);
+        String expected = IcebergSinkFactory.toEventDate(e.windowStartMs);
+        assertEquals(StringData.fromString(expected), row.getString(4));
+    }
+
+    @Test
+    void toRowData_eventDate_isDateOfWindowStart_notWindowEnd() {
+        // windowStart on 2024-06-30, windowEnd crosses midnight into 2024-07-01
+        long startMs = LocalDate.of(2024, 6, 30)
+                .atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli() + 3_600_000L; // 01:00 UTC
+        long endMs   = startMs + 3_600_000L; // 02:00 UTC, same day
+        UserEventCount e = new UserEventCount("u", 1, startMs, endMs);
+
+        RowData row = IcebergSinkFactory.toRowData(e);
+        assertEquals(StringData.fromString("2024-06-30"), row.getString(4));
+    }
+
+    // ── buildWriteProperties ──────────────────────────────────────────────────
+
+    @Test
+    void buildWriteProperties_containsRequiredKeys() {
+        var props = IcebergSinkFactory.buildWriteProperties();
+        assertTrue(props.containsKey("write.target-file-size-bytes"));
+        assertTrue(props.containsKey("write.format.default"));
+        assertTrue(props.containsKey("write.parquet.row-group-size-bytes"));
+        assertTrue(props.containsKey("write.parquet.page-size-bytes"));
+    }
+
+    @Test
+    void buildWriteProperties_defaultFormat_isParquet() {
+        assertEquals("parquet", IcebergSinkFactory.buildWriteProperties()
+                .get("write.format.default"));
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static UserEventCount sampleEvent() {
+        long startMs = LocalDate.of(2024, 6, 1)
+                .atStartOfDay(ZoneOffset.UTC).toInstant().toEpochMilli();
+        return new UserEventCount("user-42", 7L, startMs, startMs + 60_000L);
+    }
+}


### PR DESCRIPTION
… maintenance job, and snapshot retention

IcebergSinkFactory:
- Add event_date (YYYY-MM-DD UTC) as field 5 in TABLE_SCHEMA (stable field IDs 1-5)
- Define PARTITION_SPEC as identity(event_date) — day-granular, human-readable partition directories; enables exact partition pruning in Spark/Trino/Flink SQL
- Extract toRowData() and toEventDate() as package-private statics (unit-testable)
- Set write.target-file-size-bytes and write.format.default on table creation
- Expose write parallelism, Parquet page/row-group size, and S3A multipart knobs via env vars (see docs/ICEBERG_OPERATIONS.md)
- Make buildHadoopConf() and buildCatalogLoader() package-private for reuse by IcebergMaintenanceJob

CdcUserEventCountJob:
- ICEBERG_ENABLED defaults to true — Iceberg is now the primary analytics store
- Disable only via ICEBERG_ENABLED=false (local dev); log a warning when disabled
- Default ICEBERG_WAREHOUSE changed to s3a://streamforge/warehouse (MinIO-ready)
- Add full checkpoint/restart/Kafka-producer tuning knobs (from docs/tuning branch)

IcebergMaintenanceJob (new):
- Standalone Java main in maintenance package — runs without a Flink cluster
- Phase 1: expire snapshots older than SNAPSHOT_MAX_AGE_HOURS (default 168h/7d), retain at least SNAPSHOT_RETAIN_LAST (default 10) recent snapshots
- Phase 2: rewriteManifests() to merge per-checkpoint manifest fragments
- Phase 3: scan live data files, report small-file count per partition as compaction candidates (actual data-file compaction requires a Flink batch run)
- DRY_RUN=true mode reports without committing any changes
- Returns MaintenanceResult summary with all phase stats and duration

MaintenanceResult (new): summary POJO with toString() for logging/alerting

IcebergSinkFactoryTest (new, 17 tests):
- Schema: 5 fields, stable field IDs, all required, event_date is StringType
- Partition spec: 1 field, identity transform, correct source field ID
- toEventDate: ISO date, midnight boundaries, DST-safe
- toRowData: arity 5, all 5 fields mapped correctly, event_date from windowStart
- buildWriteProperties: required keys present, default format is parquet

docker-compose.yml:
- Add iceberg-maintenance service: runs IcebergMaintenanceJob in a loop every MAINTENANCE_INTERVAL_SECONDS (default 3600); supports DRY_RUN override

pom.xml:
- Add comment documenting how to invoke IcebergMaintenanceJob from the fat JAR

docs/ICEBERG_OPERATIONS.md (new):
- Partitioning rationale (identity vs timestamp transform, UTC day, late data)
- Data-file compaction: when to compact, Flink batch command, tuning table
- Snapshot retention: what expires, what is retained, how to adjust the window
- Manifest compaction: why manifests fragment, what rewriteManifests() does
- Automated maintenance: docker-compose service, dry-run, manual trigger
- Manual runbook: expire snapshots, roll back, list partitions
- Querying: Flink SQL catalog setup, PyIceberg example with partition pruning
- Schema evolution: adding optional columns, partition evolution guidance