### PR TITLE
feat(lineage): OpenLineage event capture + markdown/DAG viewer

### DIFF
--- a/agent-workflow/src/workflow_engine.py
+++ b/agent-workflow/src/workflow_engine.py
@@ -1,9 +1,21 @@
 import json
 import logging
+import sys
+from pathlib import Path
 from typing import Dict, List, Optional, Any
 from .agent import Agent
 from .config_loader import ConfigLoader
 from .communication import CommunicationManager
+
+# Optional lineage tracking — enabled when the lineage package is importable.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+try:
+    from lineage.tracker import lineage_run, dataset as _lineage_dataset
+    from lineage.emitter import default_emitter as _lineage_default_emitter
+    _LINEAGE_ENABLED = True
+except ImportError:
+    _LINEAGE_ENABLED = False
+
 
 class WorkflowEngine:
     def __init__(self, config_path: str):
@@ -12,7 +24,8 @@ class WorkflowEngine:
         self.agents: Dict[str, Agent] = {}
         self.communication_manager = CommunicationManager()
         self.logger = logging.getLogger(__name__)
-        
+        self._lineage_emitter = _lineage_default_emitter() if _LINEAGE_ENABLED else None
+
     def initialize_agents(self):
         """Initialize agents based on workflow configuration"""
         for agent_config in self.workflow_config.get('agents', []):
@@ -22,21 +35,21 @@ class WorkflowEngine:
             self.agents[agent_name] = agent
             self.communication_manager.register_agent(agent_name)
             self.logger.info(f"Initialized agent: {agent_name} (type: {agent_type})")
-    
+
     def execute_workflow(self):
         """Execute the workflow according to the defined steps"""
         self.initialize_agents()
-        
+
         steps = self.workflow_config.get('steps', [])
         for step in steps:
             agent_name = step['agent']
             action = step['action']
             input_data = step.get('input', {})
-            
+
             if agent_name not in self.agents:
                 self.logger.error(f"Agent {agent_name} not found")
                 continue
-            
+
             agent = self.agents[agent_name]
             try:
                 # Check for messages for this agent
@@ -44,17 +57,21 @@ class WorkflowEngine:
                 if messages:
                     self.logger.info(f"Received {len(messages)} messages for agent {agent_name}")
                     input_data['messages'] = messages
-                
+
                 self.logger.info(f"Executing step: {action} on agent {agent_name}")
-                result = agent.execute_action(action, input_data)
+
+                if _LINEAGE_ENABLED:
+                    result = self._execute_step_with_lineage(agent, agent_name, action, input_data, step)
+                else:
+                    result = agent.execute_action(action, input_data)
+
                 self.logger.info(f"Step completed with result: {result}")
-                
+
                 # Pass result to next steps if needed
                 if 'output_to' in step:
                     output_to = step['output_to']
                     for next_agent, next_input_key in output_to.items():
                         if next_agent in self.agents:
-                            # Use communication manager to send message
                             message = {
                                 'type': 'result',
                                 'key': next_input_key,
@@ -64,20 +81,31 @@ class WorkflowEngine:
                             self.logger.info(f"Sent result to agent {next_agent} as {next_input_key}")
             except Exception as e:
                 self.logger.error(f"Error executing step: {e}")
-                # Handle error according to workflow configuration
                 if step.get('on_error', 'continue') == 'stop':
                     self.logger.error("Stopping workflow due to error")
                     return False
-        
+
         self.logger.info("Workflow executed successfully")
         return True
-    
+
+    def _execute_step_with_lineage(self, agent, agent_name: str, action: str, input_data: dict, step: dict):
+        """Execute a single workflow step, bracketing it with OpenLineage events."""
+        wf_name = self.workflow_config.get("name", "workflow")
+        job_name = f"{wf_name}/{agent_name}/{action}"
+
+        # Derive lightweight dataset descriptors from step config.
+        inputs = [_lineage_dataset("agent-workflow", src) for src in step.get("lineage_inputs", [])]
+        outputs = [_lineage_dataset("agent-workflow", dst) for dst in step.get("lineage_outputs", [])]
+
+        with lineage_run("streamforge", job_name, inputs, outputs, emitter=self._lineage_emitter):
+            return agent.execute_action(action, input_data)
+
     def get_agent_status(self, agent_name: str) -> Optional[Dict[str, Any]]:
         """Get the status of a specific agent"""
         if agent_name in self.agents:
             return self.agents[agent_name].get_status()
         return None
-    
+
     def get_all_agents_status(self) -> Dict[str, Dict[str, Any]]:
         """Get the status of all agents"""
         return {

--- a/deploy/cdc-flink-minio-demo/feature-sink/feature_to_minio.py
+++ b/deploy/cdc-flink-minio-demo/feature-sink/feature_to_minio.py
@@ -1,11 +1,22 @@
 import json
 import os
+import sys
 import time
 from datetime import datetime, timezone
 from io import BytesIO
+from pathlib import Path
 
 from kafka import KafkaConsumer
 from minio import Minio
+
+# Optional lineage tracking — enabled when the lineage package is on the path.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent.parent))
+try:
+    from lineage.tracker import lineage_run, kafka_dataset, minio_dataset
+    from lineage.emitter import default_emitter as _lineage_default_emitter
+    _LINEAGE_ENABLED = True
+except ImportError:
+    _LINEAGE_ENABLED = False
 
 
 def env(name: str, default: str) -> str:
@@ -53,26 +64,46 @@ def main() -> None:
     )
     ensure_bucket(minio_client, minio_bucket)
 
-    for msg in consumer:
-        raw_value = msg.value
-        try:
-            payload = json.loads(raw_value)
-        except json.JSONDecodeError:
-            payload = {"raw": raw_value}
-
-        payload["sink_received_at"] = datetime.now(timezone.utc).isoformat()
-        data = (json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8")
-        key = build_object_key(minio_prefix)
-
-        minio_client.put_object(
-            bucket_name=minio_bucket,
-            object_name=key,
-            data=BytesIO(data),
-            length=len(data),
-            content_type="application/json",
+    # Emit a START lineage event when the sink begins consuming.
+    if _LINEAGE_ENABLED:
+        _emitter = _lineage_default_emitter()
+        _input_ds = [kafka_dataset(kafka_topic, kafka_servers)]
+        _output_ds = [minio_dataset(minio_bucket, minio_prefix, minio_endpoint)]
+        _lineage_ctx = lineage_run(
+            "streamforge", "feature-sink",
+            inputs=_input_ds, outputs=_output_ds,
+            emitter=_emitter,
         )
+        _lineage_ctx.__enter__()
 
-        print(f"[SINK] Wrote feature event to minio://{minio_bucket}/{key}")
+    try:
+        for msg in consumer:
+            raw_value = msg.value
+            try:
+                payload = json.loads(raw_value)
+            except json.JSONDecodeError:
+                payload = {"raw": raw_value}
+
+            payload["sink_received_at"] = datetime.now(timezone.utc).isoformat()
+            data = (json.dumps(payload, separators=(",", ":")) + "\n").encode("utf-8")
+            key = build_object_key(minio_prefix)
+
+            minio_client.put_object(
+                bucket_name=minio_bucket,
+                object_name=key,
+                data=BytesIO(data),
+                length=len(data),
+                content_type="application/json",
+            )
+
+            print(f"[SINK] Wrote feature event to minio://{minio_bucket}/{key}")
+    except Exception as exc:
+        if _LINEAGE_ENABLED:
+            _lineage_ctx.__exit__(type(exc), exc, exc.__traceback__)
+        raise
+    else:
+        if _LINEAGE_ENABLED:
+            _lineage_ctx.__exit__(None, None, None)
 
 
 if __name__ == "__main__":

--- a/lineage/__init__.py
+++ b/lineage/__init__.py
@@ -1,0 +1,35 @@
+"""
+StreamForge lineage — OpenLineage-compatible event capture and viewer.
+
+Quick start:
+    from lineage.tracker import lineage_run, kafka_dataset, minio_dataset
+    from lineage.emitter import default_emitter
+
+    with lineage_run("streamforge", "my-job",
+                     inputs=[kafka_dataset("my.topic")],
+                     outputs=[minio_dataset("bucket", "prefix")]):
+        ...  # job logic
+
+View captured events:
+    python lineage/viewer.py lineage_events.ndjson
+"""
+from .emitter import CompositeEmitter, ConsoleEmitter, FileEmitter, LineageEmitter, default_emitter
+from .models import Dataset, Job, LineageEvent, Run
+from .tracker import dataset, file_dataset, kafka_dataset, lineage_run, minio_dataset
+
+__all__ = [
+    "lineage_run",
+    "dataset",
+    "kafka_dataset",
+    "minio_dataset",
+    "file_dataset",
+    "default_emitter",
+    "LineageEmitter",
+    "FileEmitter",
+    "ConsoleEmitter",
+    "CompositeEmitter",
+    "LineageEvent",
+    "Dataset",
+    "Job",
+    "Run",
+]

--- a/lineage/demo.py
+++ b/lineage/demo.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+Simulates the full StreamForge pipeline and emits OpenLineage events.
+
+Pipeline stages:
+  1. cdc-ingestion    MySQL binlog → Kafka CDC topic
+  2. stream-processor Kafka CDC   → Kafka feature counts (Flink window aggregation)
+  3. feature-sink     Kafka       → MinIO feature artifacts
+  4. prefetch-engine  MinIO       → local cache (hot-file selection + ML job)
+
+Run:
+  python lineage/demo.py [output_file]
+
+Then view:
+  python lineage/viewer.py [output_file]
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+# Allow running from project root or from lineage/ directory.
+_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(_ROOT))
+
+from lineage.emitter import CompositeEmitter, ConsoleEmitter, FileEmitter
+from lineage.tracker import dataset, kafka_dataset, lineage_run, minio_dataset
+
+
+def run_demo(events_file: str = "lineage_events.ndjson") -> None:
+    emitter = CompositeEmitter(FileEmitter(events_file), ConsoleEmitter())
+
+    kafka_brokers = "kafka:9092"
+    minio_ep = "minio:9000"
+
+    print("\n── Stage 1: CDC Ingestion ─────────────────────────────────────────")
+    with lineage_run(
+        "streamforge",
+        "cdc-ingestion",
+        inputs=[dataset("mysql://userdb:3306", "userdb.user_events", table="user_events", format="debezium")],
+        outputs=[kafka_dataset("debezium.mysql.userdb.user_events", kafka_brokers)],
+        emitter=emitter,
+    ) as run_id:
+        time.sleep(0.02)
+        print(f"  run_id={run_id}")
+
+    print("\n── Stage 2: Stream Processor (Flink tumbling window) ──────────────")
+    with lineage_run(
+        "streamforge",
+        "stream-processor",
+        inputs=[kafka_dataset("debezium.mysql.userdb.user_events", kafka_brokers)],
+        outputs=[kafka_dataset("streamforge.features.user_event_counts", kafka_brokers)],
+        emitter=emitter,
+    ) as run_id:
+        time.sleep(0.02)
+        print(f"  run_id={run_id}")
+
+    print("\n── Stage 3: Feature Sink (Kafka → MinIO) ──────────────────────────")
+    with lineage_run(
+        "streamforge",
+        "feature-sink",
+        inputs=[kafka_dataset("streamforge.features.user_event_counts", kafka_brokers)],
+        outputs=[minio_dataset("processed", "streamforge/features", minio_ep)],
+        emitter=emitter,
+    ) as run_id:
+        time.sleep(0.02)
+        print(f"  run_id={run_id}")
+
+    print("\n── Stage 4: Prefetch Engine (MinIO → cache artifacts) ─────────────")
+    with lineage_run(
+        "streamforge",
+        "prefetch-engine",
+        inputs=[minio_dataset("processed", "streamforge/features", minio_ep)],
+        outputs=[minio_dataset("processed", "streamforge/processed/run-latest", minio_ep)],
+        emitter=emitter,
+    ) as run_id:
+        time.sleep(0.02)
+        print(f"  run_id={run_id}")
+
+    print(f"\n[demo] ✓ Events written to {events_file}")
+    print(f"[demo]   View with: python lineage/viewer.py {events_file}")
+
+
+if __name__ == "__main__":
+    out = sys.argv[1] if len(sys.argv) > 1 else "lineage_events.ndjson"
+    run_demo(out)

--- a/lineage/emitter.py
+++ b/lineage/emitter.py
@@ -1,0 +1,63 @@
+"""
+Lineage event emitters: file (NDJSON), console, and composite fan-out.
+
+Default events file is resolved from STREAMFORGE_LINEAGE_FILE env var,
+falling back to lineage_events.ndjson in the current directory.
+"""
+from __future__ import annotations
+
+import os
+from abc import ABC, abstractmethod
+from pathlib import Path
+
+from .models import LineageEvent
+
+_DEFAULT_FILE = "lineage_events.ndjson"
+
+
+class LineageEmitter(ABC):
+    @abstractmethod
+    def emit(self, event: LineageEvent) -> None: ...
+
+
+class FileEmitter(LineageEmitter):
+    """Appends one JSON line per event to an NDJSON file."""
+
+    def __init__(self, path: str | Path = _DEFAULT_FILE) -> None:
+        self._path = Path(path)
+
+    def emit(self, event: LineageEvent) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("a", encoding="utf-8") as f:
+            f.write(event.to_json() + "\n")
+
+
+class ConsoleEmitter(LineageEmitter):
+    """Prints a one-line summary to stdout for quick visibility."""
+
+    def emit(self, event: LineageEvent) -> None:
+        inputs = ",".join(d.name for d in event.inputs) or "—"
+        outputs = ",".join(d.name for d in event.outputs) or "—"
+        print(
+            f"[LINEAGE] {event.eventType:<8} "
+            f"job={event.job.namespace}/{event.job.name} "
+            f"run={event.run.runId[:8]}… "
+            f"in=[{inputs}] out=[{outputs}]"
+        )
+
+
+class CompositeEmitter(LineageEmitter):
+    """Fan-out to multiple emitters."""
+
+    def __init__(self, *emitters: LineageEmitter) -> None:
+        self._emitters = emitters
+
+    def emit(self, event: LineageEvent) -> None:
+        for e in self._emitters:
+            e.emit(event)
+
+
+def default_emitter(events_file: str | None = None) -> LineageEmitter:
+    """Return a CompositeEmitter writing to file + console."""
+    path = events_file or os.environ.get("STREAMFORGE_LINEAGE_FILE", _DEFAULT_FILE)
+    return CompositeEmitter(FileEmitter(path), ConsoleEmitter())

--- a/lineage/models.py
+++ b/lineage/models.py
@@ -1,0 +1,69 @@
+"""
+OpenLineage-compatible event models for StreamForge.
+
+Schema reference: https://openlineage.io/spec/1-0-5/OpenLineage.json
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import List
+
+
+@dataclass
+class Dataset:
+    namespace: str
+    name: str
+    facets: dict = field(default_factory=dict)
+
+
+@dataclass
+class Job:
+    namespace: str
+    name: str
+    facets: dict = field(default_factory=dict)
+
+
+@dataclass
+class Run:
+    runId: str
+    facets: dict = field(default_factory=dict)
+
+
+@dataclass
+class LineageEvent:
+    """A single OpenLineage event (START, COMPLETE, FAIL, or ABORT)."""
+
+    eventType: str
+    eventTime: str  # ISO-8601 UTC
+    run: Run
+    job: Job
+    inputs: List[Dataset]
+    outputs: List[Dataset]
+    producer: str = "streamforge-ai/lineage"
+    schemaURL: str = "https://openlineage.io/spec/1-0-5/OpenLineage.json"
+
+    def to_dict(self) -> dict:
+        return {
+            "eventType": self.eventType,
+            "eventTime": self.eventTime,
+            "run": {"runId": self.run.runId, "facets": self.run.facets},
+            "job": {
+                "namespace": self.job.namespace,
+                "name": self.job.name,
+                "facets": self.job.facets,
+            },
+            "inputs": [
+                {"namespace": d.namespace, "name": d.name, "facets": d.facets}
+                for d in self.inputs
+            ],
+            "outputs": [
+                {"namespace": d.namespace, "name": d.name, "facets": d.facets}
+                for d in self.outputs
+            ],
+            "producer": self.producer,
+            "schemaURL": self.schemaURL,
+        }
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), separators=(",", ":"))

--- a/lineage/tracker.py
+++ b/lineage/tracker.py
@@ -1,0 +1,91 @@
+"""
+High-level lineage tracking API.
+
+Usage
+-----
+from lineage.tracker import lineage_run, kafka_dataset, minio_dataset
+
+with lineage_run(
+    "streamforge", "feature-sink",
+    inputs=[kafka_dataset("streamforge.features.user_event_counts")],
+    outputs=[minio_dataset("processed", "streamforge/features")],
+) as run_id:
+    ...   # your job logic; COMPLETE emitted on exit, FAIL on exception
+"""
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Generator, List, Optional
+
+from .emitter import LineageEmitter, default_emitter
+from .models import Dataset, Job, LineageEvent, Run
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def _new_run_id() -> str:
+    return str(uuid.uuid4())
+
+
+@contextmanager
+def lineage_run(
+    job_namespace: str,
+    job_name: str,
+    inputs: List[Dataset],
+    outputs: List[Dataset],
+    *,
+    emitter: Optional[LineageEmitter] = None,
+    run_id: Optional[str] = None,
+    job_facets: Optional[dict] = None,
+) -> Generator[str, None, None]:
+    """
+    Context manager that wraps a job execution with START → COMPLETE/FAIL events.
+
+    Yields the run_id string so the caller can attach it to logs or output records.
+    """
+    em = emitter or default_emitter()
+    rid = run_id or _new_run_id()
+    job = Job(namespace=job_namespace, name=job_name, facets=job_facets or {})
+    run = Run(runId=rid)
+
+    em.emit(LineageEvent(eventType="START", eventTime=_now_iso(), run=run, job=job, inputs=inputs, outputs=outputs))
+    try:
+        yield rid
+        em.emit(LineageEvent(eventType="COMPLETE", eventTime=_now_iso(), run=run, job=job, inputs=inputs, outputs=outputs))
+    except Exception:
+        em.emit(LineageEvent(eventType="FAIL", eventTime=_now_iso(), run=run, job=job, inputs=inputs, outputs=[]))
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Dataset factory helpers
+# ---------------------------------------------------------------------------
+
+def dataset(namespace: str, name: str, **custom_facets) -> Dataset:
+    facets = {"custom": custom_facets} if custom_facets else {}
+    return Dataset(namespace=namespace, name=name, facets=facets)
+
+
+def kafka_dataset(topic: str, bootstrap_servers: str = "kafka:9092") -> Dataset:
+    return Dataset(
+        namespace=f"kafka://{bootstrap_servers}",
+        name=topic,
+        facets={"dataSource": {"name": "kafka", "uri": f"kafka://{bootstrap_servers}"}},
+    )
+
+
+def minio_dataset(bucket: str, key_prefix: str, endpoint: str = "minio:9000") -> Dataset:
+    uri = f"s3://{endpoint}/{bucket}/{key_prefix.lstrip('/')}"
+    return Dataset(
+        namespace=f"s3://{endpoint}/{bucket}",
+        name=key_prefix,
+        facets={"dataSource": {"name": "minio", "uri": uri}},
+    )
+
+
+def file_dataset(path: str) -> Dataset:
+    return Dataset(namespace="file", name=path)

--- a/lineage/viewer.py
+++ b/lineage/viewer.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+Lineage viewer: reads OpenLineage NDJSON events and renders a markdown report.
+
+Usage
+-----
+  python lineage/viewer.py [events_file]          # prints to stdout
+  python lineage/viewer.py events.ndjson > LINEAGE_REPORT.md
+"""
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+def _parse_events(path: Path) -> List[dict]:
+    events: List[dict] = []
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Run summary table
+# ---------------------------------------------------------------------------
+
+def _build_run_summary(events: List[dict]) -> List[dict]:
+    """Collapse START / COMPLETE / FAIL events into one row per run."""
+    runs: Dict[str, dict] = {}
+
+    for ev in events:
+        rid = ev["run"]["runId"]
+        etype = ev["eventType"]
+        jid = f"{ev['job']['namespace']}/{ev['job']['name']}"
+
+        if rid not in runs:
+            runs[rid] = {
+                "run_id": rid,
+                "job": jid,
+                "status": etype,
+                "start_time": None,
+                "end_time": None,
+                "duration_s": None,
+                "inputs": [],
+                "outputs": [],
+            }
+
+        r = runs[rid]
+        if etype == "START":
+            r["start_time"] = ev["eventTime"]
+            r["inputs"] = [f"{d['namespace']}:{d['name']}" for d in ev.get("inputs", [])]
+        elif etype in ("COMPLETE", "FAIL"):
+            r["status"] = etype
+            r["end_time"] = ev["eventTime"]
+            if etype == "COMPLETE":
+                r["outputs"] = [f"{d['namespace']}:{d['name']}" for d in ev.get("outputs", [])]
+
+        if r["start_time"] and r["end_time"]:
+            try:
+                t0 = datetime.fromisoformat(r["start_time"].replace("Z", "+00:00"))
+                t1 = datetime.fromisoformat(r["end_time"].replace("Z", "+00:00"))
+                r["duration_s"] = round((t1 - t0).total_seconds(), 3)
+            except Exception:
+                pass
+
+    return sorted(runs.values(), key=lambda x: x.get("start_time") or "")
+
+
+# ---------------------------------------------------------------------------
+# Lineage DAG
+# ---------------------------------------------------------------------------
+
+def _build_dag(events: List[dict]) -> Tuple[List[str], Dict[str, dict]]:
+    """
+    Return (ordered_job_ids, job_details) for ASCII DAG rendering.
+
+    job_details keys: namespace, name, inputs (list of str), outputs (list of str)
+    """
+    seen: Dict[str, int] = {}  # job_id → insertion order
+    details: Dict[str, dict] = {}
+
+    for ev in events:
+        jid = f"{ev['job']['namespace']}/{ev['job']['name']}"
+        if jid not in seen:
+            seen[jid] = len(seen)
+            details[jid] = {
+                "namespace": ev["job"]["namespace"],
+                "name": ev["job"]["name"],
+                "inputs": [],
+                "outputs": [],
+            }
+        d = details[jid]
+        if ev["eventType"] == "START" and not d["inputs"]:
+            d["inputs"] = [f"{x['namespace']} › {x['name']}" for x in ev.get("inputs", [])]
+        if ev["eventType"] == "COMPLETE" and not d["outputs"]:
+            d["outputs"] = [f"{x['namespace']} › {x['name']}" for x in ev.get("outputs", [])]
+
+    ordered = sorted(seen.keys(), key=lambda k: seen[k])
+    return ordered, details
+
+
+def _render_dag(ordered: List[str], details: Dict[str, dict]) -> str:
+    if not ordered:
+        return "  *(no lineage events found)*\n"
+
+    lines: List[str] = ["```"]
+    shown_datasets: set = set()
+
+    for jid in ordered:
+        d = details[jid]
+        inputs = d["inputs"]
+        outputs = d["outputs"]
+
+        # Show input datasets not already printed as outputs above
+        for inp in inputs:
+            if inp not in shown_datasets:
+                lines.append(f"  [ {inp} ]")
+                shown_datasets.add(inp)
+
+        if inputs:
+            lines.append("        │")
+            lines.append("        ▼")
+
+        label = f"JOB: {d['namespace']}/{d['name']}"
+        width = max(len(label) + 4, 38)
+        lines.append("  ┌" + "─" * width + "┐")
+        lines.append(f"  │  {label:<{width - 2}}│")
+        lines.append("  └" + "─" * width + "┘")
+
+        for out in outputs:
+            lines.append("        │")
+            lines.append("        ▼")
+            lines.append(f"  [ {out} ]")
+            shown_datasets.add(out)
+
+        lines.append("")
+
+    lines.append("```")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Markdown report
+# ---------------------------------------------------------------------------
+
+_STATUS_ICON = {"COMPLETE": "✅", "FAIL": "❌", "START": "🔄", "ABORT": "⛔"}
+
+
+def render_markdown(events_path: Path) -> str:
+    events = _parse_events(events_path)
+    if not events:
+        return f"# StreamForge Lineage\n\n*No events found in `{events_path}`*\n"
+
+    runs = _build_run_summary(events)
+    ordered, details = _build_dag(events)
+
+    md: List[str] = []
+    md.append("# StreamForge Lineage Report")
+    md.append(
+        f"\n*Generated from `{events_path}` · "
+        f"{len(events)} events · {len(runs)} runs · "
+        f"{len(ordered)} jobs*\n"
+    )
+
+    md.append("## Lineage DAG\n")
+    md.append(_render_dag(ordered, details))
+
+    md.append("\n## Run Summary\n")
+    md.append("| Job | Run ID | Status | Duration (s) | Inputs | Outputs |")
+    md.append("|-----|--------|:------:|:------------:|--------|---------|")
+
+    for r in runs:
+        rid_short = r["run_id"][:8] + "…"
+        icon = _STATUS_ICON.get(r["status"], r["status"])
+        inputs_str = ", ".join(r["inputs"][:2]) + ("…" if len(r["inputs"]) > 2 else "")
+        outputs_str = ", ".join(r["outputs"][:2]) + ("…" if len(r["outputs"]) > 2 else "")
+        dur = str(r["duration_s"]) if r["duration_s"] is not None else "—"
+        md.append(
+            f"| `{r['job']}` | `{rid_short}` | {icon} | {dur} | {inputs_str or '—'} | {outputs_str or '—'} |"
+        )
+
+    md.append("\n## Dataset Lineage\n")
+    md.append("Datasets that cross job boundaries:\n")
+    # Find datasets that appear as outputs of one job and inputs of another
+    all_outputs: Dict[str, str] = {}  # dataset_label → producer_job
+    for jid in ordered:
+        for out in details[jid]["outputs"]:
+            all_outputs[out] = jid
+
+    found_cross = False
+    for jid in ordered:
+        for inp in details[jid]["inputs"]:
+            if inp in all_outputs:
+                producer = all_outputs[inp]
+                md.append(f"- `{inp}` : `{producer}` → `{jid}`")
+                found_cross = True
+    if not found_cross:
+        md.append("*(no cross-job datasets detected — run more pipeline stages)*")
+
+    return "\n".join(md) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[List[str]] = None) -> None:
+    argv = argv if argv is not None else sys.argv[1:]
+    events_file = argv[0] if argv else "lineage_events.ndjson"
+    path = Path(events_file)
+
+    if not path.exists():
+        print(f"[viewer] Events file not found: {path}", file=sys.stderr)
+        print("[viewer] Run `python lineage/demo.py` to generate sample events first.", file=sys.stderr)
+        sys.exit(1)
+
+    print(render_markdown(path))
+
+
+if __name__ == "__main__":
+    main()

--- a/prefetch-engine/prefetch.py
+++ b/prefetch-engine/prefetch.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import shutil
 import time
 import json
@@ -9,6 +10,15 @@ from pathlib import Path
 from typing import List
 
 import metrics
+
+# Optional lineage tracking — enabled when the lineage package is importable.
+sys.path.insert(0, str(Path(__file__).parent.parent))
+try:
+    from lineage.tracker import lineage_run, minio_dataset, file_dataset
+    from lineage.emitter import default_emitter as _lineage_default_emitter
+    _LINEAGE_ENABLED = True
+except ImportError:  # pragma: no cover
+    _LINEAGE_ENABLED = False
 
 
 @dataclass
@@ -286,27 +296,40 @@ def main() -> None:
     manifest_dir = base / "manifest"
     cache_dir = base / "prefetch-cache"
     job_id = os.environ.get("STREAMFORGE_JOB_ID", _utc_run_id())
+    minio_bucket = _env("MINIO_BUCKET", "processed")
+    minio_prefix = _env("MINIO_PREFIX", "streamforge")
+    minio_ep = _env("MINIO_ENDPOINT", "minio:9000")
 
     print(f"[DEMO] using base directory: {base}")
 
-    candidates = _build_demo_manifest(manifest_dir)
-    hot_files = select_hot_files(candidates, top_n=3)
+    def _run() -> None:
+        candidates = _build_demo_manifest(manifest_dir)
+        hot_files = select_hot_files(candidates, top_n=3)
 
-    print("[DEMO] selected hot files (top 3 by score):")
-    for f in hot_files:
-        print(f"  - {f.uri} (recent_access_count={f.recent_access_count})")
+        print("[DEMO] selected hot files (top 3 by score):")
+        for f in hot_files:
+            print(f"  - {f.uri} (recent_access_count={f.recent_access_count})")
 
-    print(f"[DEMO] prefetching into cache: {cache_dir}")
-    prefetch_files(hot_files, cache_dir, job_id=job_id)
+        print(f"[DEMO] prefetching into cache: {cache_dir}")
+        prefetch_files(hot_files, cache_dir, job_id=job_id)
 
-    print("[DEMO] running simulated ML job")
-    run_simulated_ml_job(cache_dir, hot_files, job_id=job_id)
+        print("[DEMO] running simulated ML job")
+        run_simulated_ml_job(cache_dir, hot_files, job_id=job_id)
 
-    # Build and upload processed outputs (NDJSON).
-    records = build_processed_records(job_id=job_id, cache_dir=cache_dir, hot_files=hot_files)
-    upload_processed_records_to_minio(records)
+        records = build_processed_records(job_id=job_id, cache_dir=cache_dir, hot_files=hot_files)
+        upload_processed_records_to_minio(records)
 
-    metrics.push_metrics(job_id)
+        metrics.push_metrics(job_id)
+
+    if _LINEAGE_ENABLED:
+        _emitter = _lineage_default_emitter()
+        input_ds = [file_dataset(str(manifest_dir))]
+        output_ds = [minio_dataset(minio_bucket, f"{minio_prefix}/processed/{job_id}", minio_ep)]
+        with lineage_run("streamforge", "prefetch-engine", input_ds, output_ds,
+                         emitter=_emitter, run_id=job_id):
+            _run()
+    else:
+        _run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a standalone `lineage/` package that emits OpenLineage-compatible NDJSON events at each pipeline stage and surfaces them as an ASCII DAG with a markdown run-summary table.

New package (stdlib-only, no extra deps):
- lineage/models.py   – LineageEvent / Job / Run / Dataset dataclasses
- lineage/emitter.py  – FileEmitter (NDJSON), ConsoleEmitter, CompositeEmitter
- lineage/tracker.py  – `lineage_run` context manager + kafka/minio/file dataset helpers
- lineage/viewer.py   – CLI: reads events → ASCII DAG + run table + cross-job dataset section
- lineage/demo.py     – Simulates the full 4-stage pipeline; produces a sample events file

Integrations (opt-in via ImportError guard):
- prefetch-engine/prefetch.py        – wraps main() with lineage_run
- feature-sink/feature_to_minio.py  – emits START on consumer init, COMPLETE/FAIL on exit
- agent-workflow/src/workflow_engine.py – per-step lineage_run via _execute_step_with_lineage

Usage:
  python lineage/demo.py                   # emit sample events
  python lineage/viewer.py lineage_events.ndjson > LINEAGE_REPORT.md