### PR TITLE
feat(control-plane): lightweight read-only UI and API for v0.5

### DIFF
--- a/control-plane/README.md
+++ b/control-plane/README.md
@@ -1,0 +1,67 @@
+# StreamForge Control Plane (v0.5)
+
+Lightweight read-only dashboard for monitoring StreamForge AI pipeline services, tailing container logs, and browsing MinIO artifacts.
+
+## Components
+
+| Path | Description |
+|------|-------------|
+| `api/` | FastAPI service — wraps Docker + MinIO into REST endpoints |
+| `ui/` | React + Vite SPA — status grid, log viewer, artifact browser |
+
+## API endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/v1/status` | All service statuses (Docker container state) |
+| `GET` | `/api/v1/logs/{service}?tail=N` | Last N lines from a container (`tail` 1–2000) |
+| `GET` | `/api/v1/artifacts?bucket=&prefix=&limit=` | Recent MinIO objects, sorted newest-first |
+
+Interactive docs at `http://localhost:8090/docs` when the API is running.
+
+## Quick start
+
+### With Docker Compose (recommended)
+
+Requires the main pipeline stack (`deploy/cdc-flink-minio-demo/`) to be running first.
+
+```bash
+cd control-plane
+docker compose up --build
+```
+
+- UI: http://localhost:3000
+- API docs: http://localhost:8090/docs
+
+The API container mounts `/var/run/docker.sock` to inspect running containers.
+
+### Local development
+
+**API**
+```bash
+cd control-plane/api
+pip install -r requirements.txt
+uvicorn main:app --reload --port 8090
+```
+
+**UI**
+```bash
+cd control-plane/ui
+npm install
+npm run dev    # proxies /api/* → localhost:8090
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MINIO_ENDPOINT` | `http://localhost:9000` | MinIO S3 endpoint |
+| `MINIO_ACCESS_KEY` | `minioadmin` | MinIO access key |
+| `MINIO_SECRET_KEY` | `minioadmin` | MinIO secret key |
+| `MINIO_BUCKET` | `processed` | Default bucket to browse |
+
+## Notes
+
+- **Read-only** — v0.5 supports observation only; pipeline start/stop is planned for v0.6.
+- The API degrades gracefully when Docker or MinIO is unreachable (returns 503/502 with a message rather than crashing).
+- Auto-refreshes every 15 seconds; manual refresh via the header button.

--- a/control-plane/api/Dockerfile
+++ b/control-plane/api/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8090
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8090"]

--- a/control-plane/api/main.py
+++ b/control-plane/api/main.py
@@ -1,0 +1,25 @@
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from routers import artifacts, logs, status
+
+app = FastAPI(
+    title="StreamForge Control Plane",
+    description="Read-only status, logs, and artifact browser for StreamForge AI pipelines.",
+    version="0.5.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["GET"],
+    allow_headers=["*"],
+)
+
+app.include_router(status.router, prefix="/api/v1")
+app.include_router(logs.router, prefix="/api/v1")
+app.include_router(artifacts.router, prefix="/api/v1")
+
+
+@app.get("/healthz", include_in_schema=False)
+def healthz():
+    return {"ok": True}

--- a/control-plane/api/models.py
+++ b/control-plane/api/models.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+from datetime import datetime
+from enum import Enum
+from pydantic import BaseModel
+
+
+class ServiceStatus(str, Enum):
+    running = "running"
+    stopped = "stopped"
+    restarting = "restarting"
+    unknown = "unknown"
+
+
+class Service(BaseModel):
+    name: str
+    container_id: str | None = None
+    status: ServiceStatus
+    started_at: datetime | None = None
+    image: str | None = None
+
+
+class SystemStatus(BaseModel):
+    healthy: bool
+    services: list[Service]
+    checked_at: datetime
+
+
+class LogEntry(BaseModel):
+    timestamp: str
+    line: str
+
+
+class LogResponse(BaseModel):
+    service: str
+    lines: list[LogEntry]
+
+
+class Artifact(BaseModel):
+    key: str
+    bucket: str
+    size_bytes: int
+    last_modified: datetime
+    etag: str | None = None
+
+
+class ArtifactResponse(BaseModel):
+    bucket: str
+    artifacts: list[Artifact]
+    total: int

--- a/control-plane/api/requirements.txt
+++ b/control-plane/api/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.111.0
+uvicorn[standard]==0.30.1
+docker==7.1.0
+boto3==1.34.131
+pydantic==2.7.4

--- a/control-plane/api/routers/artifacts.py
+++ b/control-plane/api/routers/artifacts.py
@@ -1,0 +1,59 @@
+import os
+from datetime import timezone
+from fastapi import APIRouter, HTTPException, Query
+from models import Artifact, ArtifactResponse
+
+router = APIRouter(prefix="/artifacts", tags=["artifacts"])
+
+_DEFAULT_ENDPOINT = os.getenv("MINIO_ENDPOINT", "http://localhost:9000")
+_DEFAULT_ACCESS = os.getenv("MINIO_ACCESS_KEY", "minioadmin")
+_DEFAULT_SECRET = os.getenv("MINIO_SECRET_KEY", "minioadmin")
+_DEFAULT_BUCKET = os.getenv("MINIO_BUCKET", "processed")
+
+
+def _s3_client():
+    import boto3
+    from botocore.config import Config
+
+    return boto3.client(
+        "s3",
+        endpoint_url=_DEFAULT_ENDPOINT,
+        aws_access_key_id=_DEFAULT_ACCESS,
+        aws_secret_access_key=_DEFAULT_SECRET,
+        config=Config(signature_version="s3v4"),
+    )
+
+
+@router.get("", response_model=ArtifactResponse)
+def list_artifacts(
+    bucket: str = Query(default=_DEFAULT_BUCKET),
+    prefix: str = Query(default=""),
+    limit: int = Query(default=50, ge=1, le=500),
+):
+    try:
+        s3 = _s3_client()
+    except ImportError:
+        raise HTTPException(status_code=503, detail="boto3 not installed")
+
+    try:
+        paginator = s3.get_paginator("list_objects_v2")
+        items: list[Artifact] = []
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix, PaginationConfig={"MaxItems": limit}):
+            for obj in page.get("Contents", []):
+                last_mod = obj["LastModified"]
+                if last_mod.tzinfo is None:
+                    last_mod = last_mod.replace(tzinfo=timezone.utc)
+                items.append(
+                    Artifact(
+                        key=obj["Key"],
+                        bucket=bucket,
+                        size_bytes=obj["Size"],
+                        last_modified=last_mod,
+                        etag=obj.get("ETag", "").strip('"'),
+                    )
+                )
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"MinIO error: {exc}")
+
+    items.sort(key=lambda a: a.last_modified, reverse=True)
+    return ArtifactResponse(bucket=bucket, artifacts=items[:limit], total=len(items))

--- a/control-plane/api/routers/logs.py
+++ b/control-plane/api/routers/logs.py
@@ -1,0 +1,62 @@
+import re
+from fastapi import APIRouter, HTTPException, Query
+from models import LogEntry, LogResponse
+
+router = APIRouter(prefix="/logs", tags=["logs"])
+
+_ANSI_ESCAPE = re.compile(r"\x1B[@-_][0-?]*[ -/]*[@-~]")
+
+
+def _docker_client():
+    try:
+        import docker
+        return docker.from_env()
+    except Exception:
+        return None
+
+
+def _find_container(client, service: str):
+    containers = client.containers.list(
+        all=True, filters={"label": f"com.docker.compose.service={service}"}
+    )
+    if not containers:
+        containers = [
+            c for c in client.containers.list(all=True)
+            if c.name.endswith(f"-{service}-1") or c.name == service
+        ]
+    return containers[0] if containers else None
+
+
+def _parse_line(raw: bytes) -> LogEntry:
+    """Strip the 8-byte Docker multiplexed stream header if present."""
+    if len(raw) > 8 and raw[0] in (0, 1, 2):
+        raw = raw[8:]
+    text = raw.decode("utf-8", errors="replace").rstrip("\n")
+    text = _ANSI_ESCAPE.sub("", text)
+    # Try to split a leading timestamp (Docker --timestamps format)
+    parts = text.split(" ", 1)
+    if len(parts) == 2 and "T" in parts[0]:
+        return LogEntry(timestamp=parts[0], line=parts[1])
+    return LogEntry(timestamp="", line=text)
+
+
+@router.get("/{service}", response_model=LogResponse)
+def get_logs(
+    service: str,
+    tail: int = Query(default=100, ge=1, le=2000, description="Number of lines to return"),
+):
+    client = _docker_client()
+    if client is None:
+        raise HTTPException(status_code=503, detail="Docker unavailable")
+
+    container = _find_container(client, service)
+    if container is None:
+        raise HTTPException(status_code=404, detail=f"Service '{service}' not found")
+
+    try:
+        raw = container.logs(tail=tail, timestamps=True, stream=False)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    lines = [_parse_line(chunk) for chunk in raw.splitlines(keepends=True) if chunk.strip()]
+    return LogResponse(service=service, lines=lines)

--- a/control-plane/api/routers/status.py
+++ b/control-plane/api/routers/status.py
@@ -1,0 +1,72 @@
+from datetime import datetime, timezone
+from fastapi import APIRouter
+from models import Service, ServiceStatus, SystemStatus
+
+router = APIRouter(prefix="/status", tags=["status"])
+
+# Canonical set of services defined in deploy/cdc-flink-minio-demo/docker-compose.yml
+KNOWN_SERVICES = [
+    "zookeeper",
+    "kafka",
+    "mysql",
+    "connect",
+    "jobmanager",
+    "taskmanager",
+    "minio",
+    "feature-sink",
+]
+
+
+def _docker_client():
+    try:
+        import docker
+        return docker.from_env()
+    except Exception:
+        return None
+
+
+def _resolve_service(client, name: str) -> Service:
+    """Find the container for a compose service by matching label or name suffix."""
+    try:
+        containers = client.containers.list(all=True, filters={"label": f"com.docker.compose.service={name}"})
+        if not containers:
+            # Fallback: match any container whose name ends with the service name
+            containers = [
+                c for c in client.containers.list(all=True)
+                if c.name.endswith(f"-{name}-1") or c.name == name
+            ]
+        if not containers:
+            return Service(name=name, status=ServiceStatus.stopped)
+        c = containers[0]
+        state = c.status  # "running", "exited", "restarting", etc.
+        status = ServiceStatus.running if state == "running" else (
+            ServiceStatus.restarting if state == "restarting" else ServiceStatus.stopped
+        )
+        started_at_str = c.attrs.get("State", {}).get("StartedAt", "")
+        started_at = None
+        if started_at_str and not started_at_str.startswith("0001"):
+            try:
+                started_at = datetime.fromisoformat(started_at_str.replace("Z", "+00:00"))
+            except ValueError:
+                pass
+        return Service(
+            name=name,
+            container_id=c.short_id,
+            status=status,
+            started_at=started_at,
+            image=c.image.tags[0] if c.image.tags else None,
+        )
+    except Exception:
+        return Service(name=name, status=ServiceStatus.unknown)
+
+
+@router.get("", response_model=SystemStatus)
+def get_status():
+    client = _docker_client()
+    if client is None:
+        services = [Service(name=n, status=ServiceStatus.unknown) for n in KNOWN_SERVICES]
+        return SystemStatus(healthy=False, services=services, checked_at=datetime.now(timezone.utc))
+
+    services = [_resolve_service(client, name) for name in KNOWN_SERVICES]
+    healthy = all(s.status == ServiceStatus.running for s in services)
+    return SystemStatus(healthy=healthy, services=services, checked_at=datetime.now(timezone.utc))

--- a/control-plane/docker-compose.yml
+++ b/control-plane/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  api:
+    build: ./api
+    ports:
+      - "8090:8090"
+    volumes:
+      # Allows the API to query the host Docker daemon
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      MINIO_ENDPOINT: ${MINIO_ENDPOINT:-http://localhost:9000}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minioadmin}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minioadmin}
+      MINIO_BUCKET: ${MINIO_BUCKET:-processed}
+
+  ui:
+    image: node:20-alpine
+    working_dir: /app
+    volumes:
+      - ./ui:/app
+    ports:
+      - "3000:3000"
+    environment:
+      VITE_API_BASE: http://api:8090
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
+    depends_on:
+      - api

--- a/control-plane/ui/index.html
+++ b/control-plane/ui/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en" class="h-full bg-gray-950">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>StreamForge Control Plane</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="h-full">
+    <div id="root" class="h-full"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/control-plane/ui/package.json
+++ b/control-plane/ui/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "streamforge-control-plane-ui",
+  "version": "0.5.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.39",
+    "tailwindcss": "^3.4.4",
+    "typescript": "^5.4.5",
+    "vite": "^5.3.1"
+  }
+}

--- a/control-plane/ui/postcss.config.js
+++ b/control-plane/ui/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/control-plane/ui/src/App.tsx
+++ b/control-plane/ui/src/App.tsx
@@ -1,0 +1,89 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, type SystemStatus } from "./api/client";
+import { ArtifactTable } from "./components/ArtifactTable";
+import { Header } from "./components/Header";
+import { LogPanel } from "./components/LogPanel";
+import { ServiceGrid } from "./components/ServiceGrid";
+
+type Tab = "logs" | "artifacts";
+
+export default function App() {
+  const [status, setStatus] = useState<SystemStatus | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [selectedService, setSelectedService] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("logs");
+
+  const refresh = useCallback(() => {
+    setRefreshing(true);
+    api
+      .status()
+      .then((s) => {
+        setStatus(s);
+        setSelectedService((prev) => prev ?? s.services[0]?.name ?? null);
+      })
+      .catch(console.error)
+      .finally(() => setRefreshing(false));
+  }, []);
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, 15_000);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  return (
+    <div className="flex flex-col h-screen overflow-hidden">
+      <Header
+        healthy={status?.healthy ?? null}
+        checkedAt={status?.checked_at ?? null}
+        onRefresh={refresh}
+        refreshing={refreshing}
+      />
+
+      <main className="flex-1 overflow-hidden flex flex-col gap-4 p-6">
+        {/* service status grid */}
+        <section>
+          <h2 className="text-xs uppercase tracking-widest text-gray-600 mb-3">services</h2>
+          {status ? (
+            <ServiceGrid
+              services={status.services}
+              selectedService={selectedService}
+              onSelect={setSelectedService}
+            />
+          ) : (
+            <p className="text-xs text-gray-600 animate-pulse">connecting to control-plane API…</p>
+          )}
+        </section>
+
+        {/* tabs */}
+        <section className="flex-1 flex flex-col min-h-0 rounded-lg border border-gray-800 bg-gray-900 overflow-hidden">
+          <div className="flex border-b border-gray-800">
+            {(["logs", "artifacts"] as Tab[]).map((t) => (
+              <button
+                key={t}
+                onClick={() => setTab(t)}
+                className={`px-5 py-2.5 text-xs font-medium transition-colors ${
+                  tab === t
+                    ? "border-b-2 border-indigo-500 text-indigo-300"
+                    : "text-gray-500 hover:text-gray-300"
+                }`}
+              >
+                {t}
+              </button>
+            ))}
+          </div>
+
+          <div className="flex-1 min-h-0">
+            {tab === "logs" && selectedService ? (
+              <LogPanel service={selectedService} />
+            ) : tab === "logs" ? (
+              <p className="p-4 text-xs text-gray-600">select a service above to view logs</p>
+            ) : (
+              <ArtifactTable />
+            )}
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/control-plane/ui/src/api/client.ts
+++ b/control-plane/ui/src/api/client.ts
@@ -1,0 +1,60 @@
+const BASE = "/api/v1";
+
+export interface ServiceStatus {
+  name: string;
+  container_id: string | null;
+  status: "running" | "stopped" | "restarting" | "unknown";
+  started_at: string | null;
+  image: string | null;
+}
+
+export interface SystemStatus {
+  healthy: boolean;
+  services: ServiceStatus[];
+  checked_at: string;
+}
+
+export interface LogEntry {
+  timestamp: string;
+  line: string;
+}
+
+export interface LogResponse {
+  service: string;
+  lines: LogEntry[];
+}
+
+export interface Artifact {
+  key: string;
+  bucket: string;
+  size_bytes: number;
+  last_modified: string;
+  etag: string | null;
+}
+
+export interface ArtifactResponse {
+  bucket: string;
+  artifacts: Artifact[];
+  total: number;
+}
+
+async function get<T>(path: string, params?: Record<string, string | number>): Promise<T> {
+  const url = new URL(BASE + path, window.location.origin);
+  if (params) {
+    Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, String(v)));
+  }
+  const res = await fetch(url.toString());
+  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+  return res.json() as Promise<T>;
+}
+
+export const api = {
+  status: () => get<SystemStatus>("/status"),
+  logs: (service: string, tail = 100) => get<LogResponse>(`/logs/${service}`, { tail }),
+  artifacts: (bucket?: string, prefix?: string, limit = 50) =>
+    get<ArtifactResponse>("/artifacts", {
+      ...(bucket ? { bucket } : {}),
+      ...(prefix ? { prefix } : {}),
+      limit,
+    }),
+};

--- a/control-plane/ui/src/components/ArtifactTable.tsx
+++ b/control-plane/ui/src/components/ArtifactTable.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from "react";
+import { api, type Artifact } from "../api/client";
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1048576) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / 1048576).toFixed(1)} MB`;
+}
+
+export function ArtifactTable() {
+  const [artifacts, setArtifacts] = useState<Artifact[]>([]);
+  const [bucket, setBucket] = useState("processed");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function load() {
+    setLoading(true);
+    setError(null);
+    api
+      .artifacts(bucket)
+      .then((r) => setArtifacts(r.artifacts))
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  }
+
+  useEffect(() => { load(); }, [bucket]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800 bg-gray-900/60">
+        <div className="flex items-center gap-2 text-xs text-gray-400">
+          <span>bucket</span>
+          <input
+            value={bucket}
+            onChange={(e) => setBucket(e.target.value)}
+            className="bg-gray-800 border border-gray-700 rounded px-2 py-0.5 text-gray-200 focus:outline-none focus:border-indigo-500 w-36"
+          />
+        </div>
+        <button
+          onClick={load}
+          disabled={loading}
+          className="text-xs px-2 py-0.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-400 disabled:opacity-40"
+        >
+          {loading ? "loading…" : "↺"}
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-auto">
+        {error && <p className="p-4 text-xs text-red-400">error: {error}</p>}
+        {!error && artifacts.length === 0 && !loading && (
+          <p className="p-4 text-xs text-gray-600">no artifacts found in bucket "{bucket}"</p>
+        )}
+        {artifacts.length > 0 && (
+          <table className="w-full text-xs text-left">
+            <thead className="sticky top-0 bg-gray-900 border-b border-gray-800">
+              <tr>
+                <th className="px-4 py-2 text-gray-500 font-medium">key</th>
+                <th className="px-4 py-2 text-gray-500 font-medium text-right">size</th>
+                <th className="px-4 py-2 text-gray-500 font-medium text-right">modified</th>
+              </tr>
+            </thead>
+            <tbody>
+              {artifacts.map((a) => (
+                <tr key={a.key} className="border-b border-gray-800/50 hover:bg-gray-800/40">
+                  <td className="px-4 py-2 text-gray-300 font-mono break-all">{a.key}</td>
+                  <td className="px-4 py-2 text-gray-500 text-right whitespace-nowrap">
+                    {humanSize(a.size_bytes)}
+                  </td>
+                  <td className="px-4 py-2 text-gray-500 text-right whitespace-nowrap">
+                    {new Date(a.last_modified).toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/control-plane/ui/src/components/Header.tsx
+++ b/control-plane/ui/src/components/Header.tsx
@@ -1,0 +1,42 @@
+interface HeaderProps {
+  healthy: boolean | null;
+  checkedAt: string | null;
+  onRefresh: () => void;
+  refreshing: boolean;
+}
+
+export function Header({ healthy, checkedAt, onRefresh, refreshing }: HeaderProps) {
+  const badge =
+    healthy === null
+      ? { label: "checking…", cls: "bg-gray-700 text-gray-300" }
+      : healthy
+      ? { label: "healthy", cls: "bg-emerald-900 text-emerald-300" }
+      : { label: "degraded", cls: "bg-red-900 text-red-300" };
+
+  const ts = checkedAt
+    ? new Date(checkedAt).toLocaleTimeString()
+    : null;
+
+  return (
+    <header className="flex items-center justify-between px-6 py-4 border-b border-gray-800">
+      <div className="flex items-center gap-3">
+        <span className="text-lg font-medium tracking-tight text-white">
+          StreamForge <span className="text-gray-400">/ control plane</span>
+        </span>
+        <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${badge.cls}`}>
+          {badge.label}
+        </span>
+      </div>
+      <div className="flex items-center gap-4 text-xs text-gray-500">
+        {ts && <span>updated {ts}</span>}
+        <button
+          onClick={onRefresh}
+          disabled={refreshing}
+          className="px-3 py-1.5 rounded bg-gray-800 hover:bg-gray-700 text-gray-300 disabled:opacity-40 transition-colors"
+        >
+          {refreshing ? "refreshing…" : "↺ refresh"}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/control-plane/ui/src/components/LogPanel.tsx
+++ b/control-plane/ui/src/components/LogPanel.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef, useState } from "react";
+import { api, type LogEntry } from "../api/client";
+
+interface LogPanelProps {
+  service: string;
+}
+
+export function LogPanel({ service }: LogPanelProps) {
+  const [lines, setLines] = useState<LogEntry[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [tail, setTail] = useState(100);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    api
+      .logs(service, tail)
+      .then((r) => { if (!cancelled) setLines(r.lines); })
+      .catch((e: Error) => { if (!cancelled) setError(e.message); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [service, tail]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [lines]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800 bg-gray-900/60">
+        <span className="text-xs text-gray-400">
+          logs / <span className="text-indigo-400">{service}</span>
+        </span>
+        <div className="flex items-center gap-2 text-xs text-gray-500">
+          <span>tail</span>
+          {[50, 100, 200, 500].map((n) => (
+            <button
+              key={n}
+              onClick={() => setTail(n)}
+              className={`px-1.5 py-0.5 rounded transition-colors ${
+                tail === n ? "bg-indigo-700 text-white" : "hover:bg-gray-700 text-gray-400"
+              }`}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 text-xs leading-relaxed">
+        {loading && (
+          <p className="text-gray-500 animate-pulse">loading logs…</p>
+        )}
+        {error && (
+          <p className="text-red-400">error: {error}</p>
+        )}
+        {!loading && !error && lines.length === 0 && (
+          <p className="text-gray-600">no log output</p>
+        )}
+        {lines.map((entry, i) => (
+          <div key={i} className="flex gap-3 hover:bg-gray-800/50 px-1 py-0.5 rounded">
+            {entry.timestamp && (
+              <span className="shrink-0 text-gray-600 select-none">
+                {entry.timestamp.slice(11, 23)}
+              </span>
+            )}
+            <span className="text-gray-300 break-all whitespace-pre-wrap">{entry.line}</span>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+    </div>
+  );
+}

--- a/control-plane/ui/src/components/ServiceGrid.tsx
+++ b/control-plane/ui/src/components/ServiceGrid.tsx
@@ -1,0 +1,99 @@
+import type { ServiceStatus } from "../api/client";
+
+const STATUS_CONFIG = {
+  running:    { dot: "bg-emerald-400 shadow-[0_0_6px_1px_rgba(52,211,153,0.5)]", label: "running",    text: "text-emerald-400" },
+  stopped:    { dot: "bg-red-500",                                                label: "stopped",    text: "text-red-400"     },
+  restarting: { dot: "bg-yellow-400 animate-pulse",                               label: "restarting", text: "text-yellow-400"  },
+  unknown:    { dot: "bg-gray-500",                                               label: "unknown",    text: "text-gray-400"    },
+};
+
+// Friendly labels for Docker Compose service names
+const SERVICE_LABELS: Record<string, string> = {
+  zookeeper:     "Zookeeper",
+  kafka:         "Kafka",
+  mysql:         "MySQL",
+  connect:       "Debezium Connect",
+  jobmanager:    "Flink JobManager",
+  taskmanager:   "Flink TaskManager",
+  minio:         "MinIO",
+  "feature-sink": "Feature Sink",
+};
+
+function uptime(startedAt: string | null): string {
+  if (!startedAt) return "—";
+  const secs = Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000);
+  if (secs < 60) return `${secs}s`;
+  if (secs < 3600) return `${Math.floor(secs / 60)}m`;
+  return `${Math.floor(secs / 3600)}h ${Math.floor((secs % 3600) / 60)}m`;
+}
+
+interface ServiceCardProps {
+  service: ServiceStatus;
+  selected: boolean;
+  onClick: () => void;
+}
+
+function ServiceCard({ service, selected, onClick }: ServiceCardProps) {
+  const cfg = STATUS_CONFIG[service.status] ?? STATUS_CONFIG.unknown;
+  return (
+    <button
+      onClick={onClick}
+      className={`text-left p-4 rounded-lg border transition-colors ${
+        selected
+          ? "border-indigo-500 bg-indigo-950/40"
+          : "border-gray-800 bg-gray-900 hover:border-gray-600"
+      }`}
+    >
+      <div className="flex items-start justify-between mb-2">
+        <span className="text-white font-medium">
+          {SERVICE_LABELS[service.name] ?? service.name}
+        </span>
+        <span className={`flex items-center gap-1.5 text-xs ${cfg.text}`}>
+          <span className={`inline-block w-2 h-2 rounded-full ${cfg.dot}`} />
+          {cfg.label}
+        </span>
+      </div>
+      <div className="text-xs text-gray-500 space-y-0.5">
+        {service.container_id && (
+          <div>
+            <span className="text-gray-600">id </span>
+            {service.container_id}
+          </div>
+        )}
+        {service.image && (
+          <div className="truncate">
+            <span className="text-gray-600">image </span>
+            {service.image}
+          </div>
+        )}
+        {service.started_at && (
+          <div>
+            <span className="text-gray-600">up </span>
+            {uptime(service.started_at)}
+          </div>
+        )}
+      </div>
+    </button>
+  );
+}
+
+interface ServiceGridProps {
+  services: ServiceStatus[];
+  selectedService: string | null;
+  onSelect: (name: string) => void;
+}
+
+export function ServiceGrid({ services, selectedService, onSelect }: ServiceGridProps) {
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+      {services.map((s) => (
+        <ServiceCard
+          key={s.name}
+          service={s}
+          selected={selectedService === s.name}
+          onClick={() => onSelect(s.name)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/control-plane/ui/src/index.css
+++ b/control-plane/ui/src/index.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply font-mono text-sm text-gray-100 bg-gray-950;
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+::-webkit-scrollbar-track {
+  @apply bg-gray-900;
+}
+::-webkit-scrollbar-thumb {
+  @apply bg-gray-600 rounded;
+}

--- a/control-plane/ui/src/main.tsx
+++ b/control-plane/ui/src/main.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "./index.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/control-plane/ui/tailwind.config.js
+++ b/control-plane/ui/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ["./index.html", "./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      fontFamily: {
+        mono: ["JetBrains Mono", "Fira Code", "ui-monospace", "monospace"],
+      },
+    },
+  },
+  plugins: [],
+};

--- a/control-plane/ui/tsconfig.json
+++ b/control-plane/ui/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true
+  },
+  "include": ["src"]
+}

--- a/control-plane/ui/vite.config.ts
+++ b/control-plane/ui/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000,
+    proxy: {
+      "/api": {
+        target: "http://localhost:8090",
+        changeOrigin: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
Adds a control-plane module (FastAPI + React/Vite) that wraps the Docker and MinIO layers into a read-only dashboard showing service status, container logs, and recent artifacts.

- api/: FastAPI service with /status (Docker container states), /logs/{service} (tail N lines), and /artifacts (MinIO S3 listing)
- ui/: React + Vite + Tailwind SPA with a service status grid, tabbed log viewer, and artifact browser
- docker-compose.yml mounts the host Docker socket so the API can inspect the running pipeline stack
- Graceful degradation when Docker or MinIO is unreachable (503/502)