### PR TITLE
feat(pipeline-api): minimal HTTP API to start/stop/list YAML-defined …

### DIFF
--- a/agent-workflow/src/workflow_engine.py
+++ b/agent-workflow/src/workflow_engine.py
@@ -1,9 +1,10 @@
-import json
 import logging
+import threading
 from typing import Dict, List, Optional, Any
-from .agent import Agent
-from .config_loader import ConfigLoader
-from .communication import CommunicationManager
+from agent import Agent
+from config_loader import ConfigLoader
+from communication import CommunicationManager
+
 
 class WorkflowEngine:
     def __init__(self, config_path: str):
@@ -12,7 +13,19 @@ class WorkflowEngine:
         self.agents: Dict[str, Agent] = {}
         self.communication_manager = CommunicationManager()
         self.logger = logging.getLogger(__name__)
-        
+        self._stop_event: Optional[threading.Event] = None
+
+    @classmethod
+    def from_dict(cls, config: dict, stop_event: Optional[threading.Event] = None) -> "WorkflowEngine":
+        """Construct a WorkflowEngine directly from a config dict (e.g. parsed YAML)."""
+        instance = cls.__new__(cls)
+        instance.workflow_config = config
+        instance.agents = {}
+        instance.communication_manager = CommunicationManager()
+        instance.logger = logging.getLogger(__name__)
+        instance._stop_event = stop_event
+        return instance
+
     def initialize_agents(self):
         """Initialize agents based on workflow configuration"""
         for agent_config in self.workflow_config.get('agents', []):
@@ -22,65 +35,62 @@ class WorkflowEngine:
             self.agents[agent_name] = agent
             self.communication_manager.register_agent(agent_name)
             self.logger.info(f"Initialized agent: {agent_name} (type: {agent_type})")
-    
-    def execute_workflow(self):
-        """Execute the workflow according to the defined steps"""
+
+    def execute_workflow(self, stop_event: Optional[threading.Event] = None) -> bool:
+        """Execute the workflow according to the defined steps.
+
+        Checks *stop_event* (or the one set at construction) between steps so
+        the pipeline-api can request a graceful halt without killing the thread.
+        """
+        _stop = stop_event or self._stop_event
         self.initialize_agents()
-        
+
         steps = self.workflow_config.get('steps', [])
         for step in steps:
+            if _stop and _stop.is_set():
+                self.logger.info("Stop event received — halting workflow before next step")
+                return False
+
             agent_name = step['agent']
             action = step['action']
             input_data = step.get('input', {})
-            
+
             if agent_name not in self.agents:
                 self.logger.error(f"Agent {agent_name} not found")
                 continue
-            
+
             agent = self.agents[agent_name]
             try:
-                # Check for messages for this agent
                 messages = self.communication_manager.get_messages(agent_name)
                 if messages:
                     self.logger.info(f"Received {len(messages)} messages for agent {agent_name}")
                     input_data['messages'] = messages
-                
+
                 self.logger.info(f"Executing step: {action} on agent {agent_name}")
                 result = agent.execute_action(action, input_data)
                 self.logger.info(f"Step completed with result: {result}")
-                
-                # Pass result to next steps if needed
+
                 if 'output_to' in step:
-                    output_to = step['output_to']
-                    for next_agent, next_input_key in output_to.items():
+                    for next_agent, next_input_key in step['output_to'].items():
                         if next_agent in self.agents:
-                            # Use communication manager to send message
-                            message = {
-                                'type': 'result',
-                                'key': next_input_key,
-                                'data': result
-                            }
-                            self.communication_manager.send_message(agent_name, next_agent, message)
+                            self.communication_manager.send_message(
+                                agent_name, next_agent,
+                                {'type': 'result', 'key': next_input_key, 'data': result},
+                            )
                             self.logger.info(f"Sent result to agent {next_agent} as {next_input_key}")
             except Exception as e:
                 self.logger.error(f"Error executing step: {e}")
-                # Handle error according to workflow configuration
                 if step.get('on_error', 'continue') == 'stop':
                     self.logger.error("Stopping workflow due to error")
                     return False
-        
+
         self.logger.info("Workflow executed successfully")
         return True
-    
+
     def get_agent_status(self, agent_name: str) -> Optional[Dict[str, Any]]:
-        """Get the status of a specific agent"""
         if agent_name in self.agents:
             return self.agents[agent_name].get_status()
         return None
-    
+
     def get_all_agents_status(self) -> Dict[str, Dict[str, Any]]:
-        """Get the status of all agents"""
-        return {
-            agent_name: agent.get_status()
-            for agent_name, agent in self.agents.items()
-        }
+        return {name: agent.get_status() for name, agent in self.agents.items()}

--- a/pipeline-api/manager.py
+++ b/pipeline-api/manager.py
@@ -1,0 +1,216 @@
+"""
+PipelineManager — load pipeline configs from a directory of YAML files,
+then start / stop / inspect them as background threads.
+
+No multi-tenant isolation: all pipelines share the same process and
+filesystem. Concurrent runs of the same pipeline name are rejected.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+
+# Resolve the agent-workflow package relative to this file's location.
+_REPO_ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "agent-workflow" / "src"))
+
+from workflow_engine import WorkflowEngine  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Runtime state for a single pipeline execution
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PipelineRun:
+    run_id: str
+    pipeline_name: str
+    status: str          # running | completed | failed | stopped
+    started_at: str
+    ended_at: Optional[str] = None
+    error: Optional[str] = None
+    _thread: Optional[threading.Thread] = field(default=None, repr=False)
+    _stop_event: threading.Event = field(default_factory=threading.Event, repr=False)
+
+    def to_dict(self) -> dict:
+        return {
+            "run_id": self.run_id,
+            "pipeline_name": self.pipeline_name,
+            "status": self.status,
+            "started_at": self.started_at,
+            "ended_at": self.ended_at,
+            "error": self.error,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Manager
+# ---------------------------------------------------------------------------
+
+class PipelineManager:
+    """
+    Scans *pipelines_dir* for ``*.yaml`` files on construction and keeps
+    them as pipeline definitions.  At most one run per pipeline name is
+    tracked at any time.
+    """
+
+    def __init__(self, pipelines_dir: str | Path) -> None:
+        self._dir = Path(pipelines_dir)
+        self._configs: Dict[str, dict] = {}   # name → raw config dict
+        self._runs: Dict[str, PipelineRun] = {}  # name → current/last run
+        self._lock = threading.Lock()
+        self._reload_configs()
+
+    # ------------------------------------------------------------------
+    # Config loading
+    # ------------------------------------------------------------------
+
+    def _reload_configs(self) -> None:
+        for yaml_file in sorted(self._dir.glob("*.yaml")):
+            try:
+                config = yaml.safe_load(yaml_file.read_text(encoding="utf-8"))
+            except yaml.YAMLError as exc:
+                logger.warning("Skipping %s — YAML parse error: %s", yaml_file, exc)
+                continue
+            name = config.get("name") or yaml_file.stem
+            config.setdefault("name", name)
+            config["_source"] = str(yaml_file.relative_to(_REPO_ROOT))
+            self._configs[name] = config
+            logger.info("Loaded pipeline config: %s from %s", name, yaml_file.name)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def list_pipelines(self) -> List[dict]:
+        with self._lock:
+            result = []
+            for name, cfg in self._configs.items():
+                run = self._runs.get(name)
+                result.append({
+                    "name": name,
+                    "description": cfg.get("description", ""),
+                    "config_file": cfg["_source"],
+                    "status": self._effective_status(run),
+                    "run_id": run.run_id if run else None,
+                    "started_at": run.started_at if run else None,
+                })
+            return result
+
+    def get_pipeline(self, name: str) -> Optional[dict]:
+        with self._lock:
+            cfg = self._configs.get(name)
+            if cfg is None:
+                return None
+            run = self._runs.get(name)
+            info: dict = {
+                "name": name,
+                "description": cfg.get("description", ""),
+                "config_file": cfg["_source"],
+                "agents": [a["name"] for a in cfg.get("agents", [])],
+                "steps": len(cfg.get("steps", [])),
+                "status": self._effective_status(run),
+            }
+            if run:
+                info.update(run.to_dict())
+                if run.status == "running" and run._thread:
+                    info["agent_statuses"] = {}  # populated by engine post-run
+            return info
+
+    def start_pipeline(self, name: str) -> dict:
+        with self._lock:
+            if name not in self._configs:
+                raise KeyError(f"Pipeline '{name}' not found")
+
+            run = self._runs.get(name)
+            if run and run.status == "running":
+                raise RuntimeError(f"Pipeline '{name}' is already running (run_id={run.run_id})")
+
+            run_id = uuid.uuid4().hex[:8]
+            stop_event = threading.Event()
+            new_run = PipelineRun(
+                run_id=run_id,
+                pipeline_name=name,
+                status="running",
+                started_at=_now(),
+                _stop_event=stop_event,
+            )
+            self._runs[name] = new_run
+
+            config = dict(self._configs[name])  # shallow copy; engine doesn't mutate top-level
+
+        t = threading.Thread(
+            target=self._run_pipeline,
+            args=(name, config, new_run),
+            name=f"pipeline-{name}-{run_id}",
+            daemon=True,
+        )
+        new_run._thread = t
+        t.start()
+
+        return {"run_id": run_id, "status": "running", "started_at": new_run.started_at}
+
+    def stop_pipeline(self, name: str, timeout_s: float = 5.0) -> dict:
+        with self._lock:
+            run = self._runs.get(name)
+            if run is None or run.status != "running":
+                raise RuntimeError(f"Pipeline '{name}' is not currently running")
+            run._stop_event.set()
+
+        # Wait outside the lock so the worker thread can update status.
+        if run._thread:
+            run._thread.join(timeout=timeout_s)
+
+        with self._lock:
+            if run.status == "running":
+                # Thread didn't finish within timeout — mark it anyway.
+                run.status = "stopped"
+                run.ended_at = _now()
+            stopped_at = run.ended_at or _now()
+
+        return {"status": run.status, "stopped_at": stopped_at}
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _run_pipeline(self, name: str, config: dict, run: PipelineRun) -> None:
+        try:
+            engine = WorkflowEngine.from_dict(config, stop_event=run._stop_event)
+            success = engine.execute_workflow()
+            with self._lock:
+                if run._stop_event.is_set():
+                    run.status = "stopped"
+                else:
+                    run.status = "completed" if success else "failed"
+                run.ended_at = _now()
+        except Exception as exc:
+            logger.exception("Pipeline '%s' raised an exception", name)
+            with self._lock:
+                run.status = "failed"
+                run.error = str(exc)
+                run.ended_at = _now()
+
+    @staticmethod
+    def _effective_status(run: Optional[PipelineRun]) -> str:
+        if run is None:
+            return "idle"
+        # Re-check thread liveness for "running" entries whose thread finished
+        # without updating status (shouldn't happen, but guard anyway).
+        if run.status == "running" and run._thread and not run._thread.is_alive():
+            return "completed"
+        return run.status

--- a/pipeline-api/pipelines/cdc_to_minio.yaml
+++ b/pipeline-api/pipelines/cdc_to_minio.yaml
@@ -1,0 +1,51 @@
+name: cdc-to-minio
+description: "Full CDC pipeline: MySQL binlog → Kafka aggregation → MinIO feature store"
+
+agents:
+  - name: data_ingestion_agent
+    type: data_ingestion
+    config:
+      source: mysql
+      host: localhost
+      port: 3306
+      database: streamforge
+
+  - name: stream_processor_agent
+    type: stream_processor
+    config:
+      mode: flink
+      parallelism: 2
+      window_size_seconds: 60
+
+  - name: storage_sink_agent
+    type: storage_sink
+    config:
+      destination: minio
+      bucket: processed
+      prefix: streamforge/features
+
+steps:
+  - agent: data_ingestion_agent
+    action: start_ingestion
+    on_error: continue
+    lineage_inputs: []
+    lineage_outputs:
+      - "kafka://kafka:9092:debezium.mysql.streamforge.user_events"
+
+  - agent: stream_processor_agent
+    action: process_stream
+    on_error: continue
+    lineage_inputs:
+      - "kafka://kafka:9092:debezium.mysql.streamforge.user_events"
+    lineage_outputs:
+      - "kafka://kafka:9092:streamforge.features.user_event_counts"
+    output_to:
+      storage_sink_agent: processed_data
+
+  - agent: storage_sink_agent
+    action: write_to_storage
+    on_error: continue
+    lineage_inputs:
+      - "kafka://kafka:9092:streamforge.features.user_event_counts"
+    lineage_outputs:
+      - "s3://minio:9000/processed:streamforge/features"

--- a/pipeline-api/pipelines/prefetch_demo.yaml
+++ b/pipeline-api/pipelines/prefetch_demo.yaml
@@ -1,0 +1,19 @@
+name: prefetch-demo
+description: "Hot-file selection + local cache staging + simulated ML job"
+
+agents:
+  - name: prefetch_agent
+    type: prefetch
+    config:
+      top_n: 3
+      simulate_latency_s: 0.05
+      cache_dir: /tmp/streamforge-demo/prefetch-cache
+
+steps:
+  - agent: prefetch_agent
+    action: run_prefetch
+    on_error: continue
+    lineage_inputs:
+      - "file:///tmp/streamforge-demo/manifest"
+    lineage_outputs:
+      - "file:///tmp/streamforge-demo/prefetch-cache"

--- a/pipeline-api/requirements.txt
+++ b/pipeline-api/requirements.txt
@@ -1,0 +1,2 @@
+flask>=3.0
+pyyaml>=6.0

--- a/pipeline-api/server.py
+++ b/pipeline-api/server.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+StreamForge Pipeline API — minimal HTTP server.
+
+Endpoints
+---------
+  GET  /health                     liveness check
+  GET  /pipelines                  list all known pipelines + runtime status
+  GET  /pipelines/<name>           detail for a single pipeline
+  POST /pipelines/<name>/start     start a pipeline (background thread)
+  POST /pipelines/<name>/stop      request graceful stop
+
+Configuration (env vars)
+------------------------
+  PIPELINE_API_HOST   bind host  (default 0.0.0.0)
+  PIPELINE_API_PORT   bind port  (default 8080)
+  PIPELINES_DIR       directory of *.yaml configs
+                      (default <repo-root>/pipeline-api/pipelines)
+
+No multi-tenant guarantees — all requests share one process.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+from flask import Flask, jsonify, request
+
+from manager import PipelineManager
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)-8s %(name)s — %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%SZ",
+)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# App + pipeline manager
+# ---------------------------------------------------------------------------
+app = Flask(__name__)
+
+_DEFAULT_PIPELINES_DIR = Path(__file__).parent / "pipelines"
+_pipelines_dir = Path(os.environ.get("PIPELINES_DIR", str(_DEFAULT_PIPELINES_DIR)))
+manager = PipelineManager(_pipelines_dir)
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+@app.get("/health")
+def health():
+    return jsonify({"status": "ok", "pipelines_dir": str(_pipelines_dir)})
+
+
+@app.get("/pipelines")
+def list_pipelines():
+    return jsonify({"pipelines": manager.list_pipelines()})
+
+
+@app.get("/pipelines/<name>")
+def get_pipeline(name: str):
+    info = manager.get_pipeline(name)
+    if info is None:
+        return jsonify({"error": f"pipeline '{name}' not found"}), 404
+    return jsonify(info)
+
+
+@app.post("/pipelines/<name>/start")
+def start_pipeline(name: str):
+    try:
+        result = manager.start_pipeline(name)
+    except KeyError:
+        return jsonify({"error": f"pipeline '{name}' not found"}), 404
+    except RuntimeError as exc:
+        return jsonify({"error": str(exc)}), 409  # conflict — already running
+    return jsonify(result), 202
+
+
+@app.post("/pipelines/<name>/stop")
+def stop_pipeline(name: str):
+    try:
+        result = manager.stop_pipeline(name)
+    except KeyError:
+        return jsonify({"error": f"pipeline '{name}' not found"}), 404
+    except RuntimeError as exc:
+        return jsonify({"error": str(exc)}), 409
+    return jsonify(result)
+
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    host = os.environ.get("PIPELINE_API_HOST", "0.0.0.0")
+    port = int(os.environ.get("PIPELINE_API_PORT", "8080"))
+    logger.info("Starting Pipeline API on %s:%s", host, port)
+    app.run(host=host, port=port)


### PR DESCRIPTION
…pipelines

Adds pipeline-api/ — a Flask HTTP server that manages pipeline lifecycles defined in YAML config files, backed by the existing WorkflowEngine.

New files:
  pipeline-api/server.py              Flask app with 5 routes (health/list/get/start/stop)
  pipeline-api/manager.py             PipelineManager: YAML loading, thread-per-pipeline,
                                      graceful stop via threading.Event
  pipeline-api/requirements.txt       flask>=3.0, pyyaml>=6.0
  pipeline-api/pipelines/cdc_to_minio.yaml     3-agent CDC→Kafka→MinIO pipeline
  pipeline-api/pipelines/prefetch_demo.yaml    Single-agent hot-file prefetch pipeline

WorkflowEngine changes (agent-workflow/src/workflow_engine.py):
  - WorkflowEngine.from_dict(config, stop_event) — construct from a dict (YAML-parsed) instead of requiring a file path
  - execute_workflow(stop_event) — checks stop_event between steps for graceful halt
  - Absolute imports to match main.py and allow direct sys.path loading

API endpoints:
  GET  /health
  GET  /pipelines
  GET  /pipelines/<name>
  POST /pipelines/<name>/start   → 202 Accepted, returns run_id
  POST /pipelines/<name>/stop    → 200, signals stop_event + joins thread (5 s timeout)

No multi-tenant guarantees; one process, shared state, at-most-one concurrent run per pipeline name (409 Conflict if already running).

Usage:
  pip install -r pipeline-api/requirements.txt
  cd pipeline-api && python server.py          # listens on :8080
  PIPELINES_DIR=./pipelines PIPELINE_API_PORT=9090 python server.py