### PR TITLE
feat(feature-store): Feast + Tecton-compatible feature store integration

### DIFF
--- a/feature-store/__init__.py
+++ b/feature-store/__init__.py
@@ -1,0 +1,72 @@
+"""
+streamforge-ai feature store — Feast + Tecton-compatible interface.
+
+Quick start (Feast style)
+-------------------------
+    from feature_store.store import FeatureStore
+    from feature_store.entities import Entity
+    from feature_store.feature_views import BatchFeatureView, StreamFeatureView, Feature, DataSource
+    from feature_store.feature_service import FeatureService
+    import datetime
+
+    user = Entity(name="user", join_key="user_id")
+
+    user_event_stats = BatchFeatureView(
+        name="user_event_stats",
+        entities=[user],
+        features=[
+            Feature.int("event_count"),
+            Feature.float("event_rate"),
+            Feature.int("window_start_ms"),
+            Feature.int("window_end_ms"),
+        ],
+        source=DataSource.minio(),
+        ttl=datetime.timedelta(days=7),
+    )
+
+    recommendation_service = FeatureService(
+        name="recommendation_service",
+        features=[user_event_stats],
+    )
+
+    store = FeatureStore(project="streamforge")
+    store.apply([user, user_event_stats, recommendation_service])
+
+    fv = store.get_online_features(
+        features=["user_event_stats:event_count"],
+        entity_rows=[{"user_id": 42}],
+    )
+    print(fv.to_dict())
+
+Quick start (Tecton style)
+--------------------------
+    from feature_store.tecton_compat import batch_feature_view, on_demand_feature_view
+
+    @batch_feature_view(sources=[DataSource.minio()], entities=[user], online=True)
+    def user_event_stats(records):
+        return records
+
+    @on_demand_feature_view(
+        sources=[user_event_stats],
+        features=[Feature.float("event_rate_normalized")],
+    )
+    def normalized_rate(inputs):
+        return {"event_rate_normalized": min(inputs.get("event_rate", 0.0) / 10.0, 1.0)}
+"""
+
+from store import FeatureStore
+from entities import Entity, ValueType
+from feature_views import BatchFeatureView, StreamFeatureView, OnDemandFeatureView, Feature, DataSource
+from feature_service import FeatureService
+
+__all__ = [
+    "FeatureStore",
+    "Entity",
+    "ValueType",
+    "BatchFeatureView",
+    "StreamFeatureView",
+    "OnDemandFeatureView",
+    "Feature",
+    "DataSource",
+    "FeatureService",
+]

--- a/feature-store/demo.py
+++ b/feature-store/demo.py
@@ -1,0 +1,222 @@
+"""
+StreamForge Feature Store — end-to-end demo.
+
+Demonstrates both Feast-compatible and Tecton-compatible APIs against
+the existing StreamForge MinIO + Redis infrastructure (falls back to
+in-memory stubs when the services are not running).
+
+Run:
+    cd feature-store
+    python demo.py
+"""
+from __future__ import annotations
+
+import datetime
+import sys
+import time
+
+# ---------------------------------------------------------------------------
+# 1. Feast-compatible API
+# ---------------------------------------------------------------------------
+
+print("=" * 60)
+print("StreamForge Feature Store Demo")
+print("=" * 60)
+
+from store import FeatureStore
+from entities import Entity
+from feature_views import BatchFeatureView, StreamFeatureView, OnDemandFeatureView, Feature, DataSource
+from feature_service import FeatureService
+
+# --- Declare objects ---
+
+user = Entity(
+    name="user",
+    join_key="user_id",
+    description="StreamForge platform user",
+)
+
+user_event_stats = BatchFeatureView(
+    name="user_event_stats",
+    entities=[user],
+    features=[
+        Feature.int("event_count"),
+        Feature.float("event_rate"),
+        Feature.int("window_start_ms"),
+        Feature.int("window_end_ms"),
+    ],
+    source=DataSource.minio(),
+    ttl=datetime.timedelta(days=7),
+    description="Per-user tumbling-window event aggregates (MinIO offline store)",
+)
+
+realtime_user_events = StreamFeatureView(
+    name="realtime_user_events",
+    entities=[user],
+    features=[
+        Feature.int("event_count"),
+        Feature.float("event_rate"),
+    ],
+    source=DataSource.kafka(topic="user.event.counts"),
+    ttl=datetime.timedelta(hours=24),
+    description="Real-time Kafka stream features (Redis online store)",
+)
+
+normalized_rate_view = OnDemandFeatureView(
+    name="normalized_event_rate",
+    sources=[user_event_stats],
+    features=[Feature.float("event_rate_normalized")],
+    transform_fn=lambda inputs: {
+        "event_rate_normalized": round(min(inputs.get("event_rate", 0.0) / 10.0, 1.0), 4)
+    },
+    description="Event rate scaled to [0, 1] (request-time computation)",
+)
+
+recommendation_service = FeatureService(
+    name="recommendation_service",
+    features=[user_event_stats, realtime_user_events],
+    description="Features used by the recommendation model",
+    owner="ml-platform",
+)
+
+# --- Register everything ---
+
+store = FeatureStore(project="streamforge")
+store.apply([
+    user,
+    user_event_stats,
+    realtime_user_events,
+    normalized_rate_view,
+    recommendation_service,
+])
+
+print(f"\n[registry] {store}")
+
+# ---------------------------------------------------------------------------
+# 2. Online serving  — Feast-compatible
+# ---------------------------------------------------------------------------
+
+print("\n--- get_online_features() [Feast-compatible] ---")
+t0 = time.perf_counter()
+fv = store.get_online_features(
+    features=[
+        "user_event_stats:event_count",
+        "user_event_stats:event_rate",
+        "user_event_stats:window_start_ms",
+    ],
+    entity_rows=[{"user_id": 1}, {"user_id": 42}, {"user_id": 99}],
+)
+elapsed_ms = (time.perf_counter() - t0) * 1000
+print(f"  result: {fv}  ({elapsed_ms:.1f} ms)")
+d = fv.to_dict()
+for uid, ec, er in zip(d.get("user_id", []), d.get("event_count", []), d.get("event_rate", [])):
+    print(f"  user_id={uid}  event_count={ec}  event_rate={er}")
+
+# ---------------------------------------------------------------------------
+# 3. Online serving  — Tecton-compatible
+# ---------------------------------------------------------------------------
+
+print("\n--- get_features() [Tecton-compatible] ---")
+t0 = time.perf_counter()
+fv2 = store.get_features(
+    join_keys={"user_id": [1, 42, 99]},
+    feature_service_name="recommendation_service",
+)
+elapsed_ms = (time.perf_counter() - t0) * 1000
+print(f"  result: {fv2}  ({elapsed_ms:.1f} ms)")
+
+# ---------------------------------------------------------------------------
+# 4. Tecton decorator API
+# ---------------------------------------------------------------------------
+
+print("\n--- Tecton decorator API ---")
+from tecton_compat import batch_feature_view, stream_feature_view, on_demand_feature_view
+
+user2 = Entity(name="user2", join_key="user_id")
+
+
+@batch_feature_view(
+    sources=[DataSource.minio()],
+    entities=[user2],
+    online=True,
+    offline=True,
+    ttl=datetime.timedelta(days=7),
+    description="Decorated batch view: passthrough with filter",
+)
+def active_user_stats(records):
+    """Return only records with event_count > 0."""
+    return [r for r in records if r.get("event_count", 0) > 0]
+
+
+@stream_feature_view(
+    source=DataSource.kafka(topic="user.event.counts"),
+    entities=[user2],
+    features=[Feature.float("events_per_minute")],
+    description="Decorated stream view: convert event_count to per-minute rate",
+)
+def realtime_event_rate(event: dict) -> dict:
+    """Scale 30-second window count to per-minute rate."""
+    return {"events_per_minute": event.get("event_count", 0) * 2.0}
+
+
+@on_demand_feature_view(
+    sources=[active_user_stats],
+    features=[Feature.float("event_rate_normalized")],
+    description="Decorated on-demand view: normalize event_rate to [0, 1]",
+)
+def normalized_event_rate_v2(inputs: dict) -> dict:
+    """Normalize event_rate to [0, 1] (cap at 10 events/s)."""
+    return {"event_rate_normalized": round(min(inputs.get("event_rate", 0.0) / 10.0, 1.0), 4)}
+
+
+print(f"  BatchFeatureView : {active_user_stats}")
+print(f"  StreamFeatureView: {realtime_event_rate}")
+print(f"  OnDemandView     : {normalized_event_rate_v2}")
+
+store2 = FeatureStore(project="streamforge-tecton")
+store2.apply([user2, active_user_stats, realtime_event_rate, normalized_event_rate_v2])
+
+fv3 = store2.get_online_features(
+    features=["active_user_stats:event_count", "active_user_stats:event_rate"],
+    entity_rows=[{"user_id": 42}, {"user_id": 7}],
+)
+print(f"  decorated view result: {fv3}")
+
+# ---------------------------------------------------------------------------
+# 5. Historical features  — RetrievalJob
+# ---------------------------------------------------------------------------
+
+print("\n--- get_historical_features() [Feast-compatible] ---")
+job = store.get_historical_features(
+    entity_df={"user_id": [1, 42, 99]},
+    features=["user_event_stats:event_count", "user_event_stats:event_rate"],
+)
+print(f"  RetrievalJob: {job}")
+try:
+    import pandas as pd
+    df = job.to_df()
+    print(f"  DataFrame shape: {df.shape}")
+    if not df.empty:
+        print(f"  Sample row: {df.iloc[0].to_dict()}")
+except ImportError:
+    print("  (pandas not installed — skipping .to_df() check)")
+
+# ---------------------------------------------------------------------------
+# 6. Materialization
+# ---------------------------------------------------------------------------
+
+print("\n--- materialize() offline → online ---")
+end_date = datetime.date.today()
+start_date = end_date - datetime.timedelta(days=1)
+store.materialize(start_date=start_date, end_date=end_date)
+
+# ---------------------------------------------------------------------------
+# 7. Stats
+# ---------------------------------------------------------------------------
+
+print("\n--- store.stats() ---")
+import json
+stats = store.stats()
+print(json.dumps(stats, indent=2, default=str))
+
+print("\n[demo] Done.")

--- a/feature-store/entities.py
+++ b/feature-store/entities.py
@@ -1,0 +1,49 @@
+"""
+Entity definitions — Feast-compatible.
+
+An Entity identifies the primary object (e.g. user) for which features
+are computed.  Every FeatureView must reference one or more entities so
+the store knows which join key to use when serving.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+class ValueType:
+    INT64 = "INT64"
+    FLOAT = "FLOAT"
+    STRING = "STRING"
+    DOUBLE = "DOUBLE"
+    BOOL = "BOOL"
+    BYTES = "BYTES"
+    UNIX_TIMESTAMP = "UNIX_TIMESTAMP"
+
+
+@dataclass
+class Entity:
+    """
+    Feast-compatible Entity.
+
+    Parameters
+    ----------
+    name : str
+        Unique name for this entity (e.g. "user").
+    join_key : str
+        Column name used to join features (e.g. "user_id").
+    value_type : str
+        Type of the join key (default INT64).
+    description : str
+        Human-readable description.
+    tags : dict
+        Arbitrary key-value metadata.
+    """
+
+    name: str
+    join_key: str
+    value_type: str = ValueType.INT64
+    description: str = ""
+    tags: dict = field(default_factory=dict)
+
+    def __repr__(self) -> str:
+        return f"Entity(name={self.name!r}, join_key={self.join_key!r})"

--- a/feature-store/feature_service.py
+++ b/feature-store/feature_service.py
@@ -1,0 +1,48 @@
+"""
+FeatureService — groups related feature views into a single serving unit.
+
+Feast-compatible: FeatureService is the primary artifact used at serving time.
+Tecton-compatible: equivalent to FeatureService.
+"""
+from __future__ import annotations
+
+from typing import List, Optional, Union
+
+from feature_views import BatchFeatureView, StreamFeatureView, OnDemandFeatureView
+
+FeatureViewType = Union[BatchFeatureView, StreamFeatureView, OnDemandFeatureView]
+
+
+class FeatureService:
+    """
+    A named collection of feature views served together.
+
+    Parameters
+    ----------
+    name        : unique service name used in get_features() lookups
+    features    : list of feature view objects to include
+    description : human-readable description
+    tags        : arbitrary key-value metadata
+    owner       : team or individual responsible for this service
+    """
+
+    def __init__(
+        self,
+        name: str,
+        features: List[FeatureViewType],
+        description: str = "",
+        tags: Optional[dict] = None,
+        owner: str = "",
+    ) -> None:
+        self.name = name
+        self.features = features
+        self.description = description
+        self.tags = tags or {}
+        self.owner = owner
+
+    @property
+    def feature_view_names(self) -> List[str]:
+        return [f.name for f in self.features]
+
+    def __repr__(self) -> str:
+        return f"FeatureService(name={self.name!r}, views={self.feature_view_names})"

--- a/feature-store/feature_views.py
+++ b/feature-store/feature_views.py
@@ -1,0 +1,246 @@
+"""
+Feature view definitions — Feast + Tecton-compatible.
+
+Three view types mirror both ecosystems:
+
+  BatchFeatureView    — offline storage (MinIO / Iceberg)
+  StreamFeatureView   — real-time stream (Kafka → Redis)
+  OnDemandFeatureView — request-time computation on top of other views
+"""
+from __future__ import annotations
+
+import datetime
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
+
+from entities import Entity
+
+
+# ---------------------------------------------------------------------------
+# Feature descriptor
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Feature:
+    """A single named feature column with type metadata."""
+
+    name: str
+    dtype: str = "FLOAT"
+    description: str = ""
+
+    @classmethod
+    def int(cls, name: str, description: str = "") -> "Feature":
+        return cls(name=name, dtype="INT64", description=description)
+
+    @classmethod
+    def float(cls, name: str, description: str = "") -> "Feature":
+        return cls(name=name, dtype="FLOAT", description=description)
+
+    @classmethod
+    def string(cls, name: str, description: str = "") -> "Feature":
+        return cls(name=name, dtype="STRING", description=description)
+
+    def __repr__(self) -> str:
+        return f"Feature({self.name!r}, dtype={self.dtype!r})"
+
+
+# ---------------------------------------------------------------------------
+# Data source pointer
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DataSource:
+    """
+    Pointer to a backing data source.
+
+    source_type : "minio" | "redis" | "kafka" | "iceberg"
+    config      : source-specific connection parameters
+    """
+
+    source_type: str
+    config: dict = field(default_factory=dict)
+
+    @classmethod
+    def minio(
+        cls,
+        bucket: str = "processed",
+        prefix: str = "streamforge/features",
+        endpoint: str = "localhost:9000",
+    ) -> "DataSource":
+        return cls("minio", {"bucket": bucket, "prefix": prefix, "endpoint": endpoint})
+
+    @classmethod
+    def redis(cls, host: str = "localhost", port: int = 6379, db: int = 0) -> "DataSource":
+        return cls("redis", {"host": host, "port": port, "db": db})
+
+    @classmethod
+    def kafka(
+        cls,
+        topic: str = "user.event.counts",
+        bootstrap_servers: str = "localhost:9092",
+    ) -> "DataSource":
+        return cls("kafka", {"topic": topic, "bootstrap_servers": bootstrap_servers})
+
+    @classmethod
+    def iceberg(cls, catalog_uri: str = "thrift://localhost:9083", warehouse: str = "s3a://processed/") -> "DataSource":
+        return cls("iceberg", {"catalog_uri": catalog_uri, "warehouse": warehouse})
+
+    def __repr__(self) -> str:
+        return f"DataSource({self.source_type!r})"
+
+
+# ---------------------------------------------------------------------------
+# BatchFeatureView
+# ---------------------------------------------------------------------------
+
+class BatchFeatureView:
+    """
+    Feast-compatible batch (offline) feature view backed by MinIO or Iceberg.
+
+    Analogous to:
+      Feast  — FeatureView with a batch source
+      Tecton — BatchFeatureView
+
+    Parameters
+    ----------
+    name        : unique view name
+    entities    : list of Entity objects this view joins on
+    features    : list of Feature columns produced by this view
+    source      : DataSource pointing to offline storage (default: MinIO)
+    ttl         : how long online cache entries remain valid
+    online      : whether features should be materialized to online store
+    tags        : arbitrary key-value metadata
+    description : human-readable description
+    """
+
+    def __init__(
+        self,
+        name: str,
+        entities: List[Entity],
+        features: List[Feature],
+        source: Optional[DataSource] = None,
+        ttl: datetime.timedelta = datetime.timedelta(days=7),
+        online: bool = True,
+        tags: Optional[dict] = None,
+        description: str = "",
+    ) -> None:
+        self.name = name
+        self.entities = entities
+        self.features = features
+        self.source = source or DataSource.minio()
+        self.ttl = ttl
+        self.online = online
+        self.tags = tags or {}
+        self.description = description
+        self._transform_fn: Optional[Callable] = None
+
+    @property
+    def join_keys(self) -> List[str]:
+        return [e.join_key for e in self.entities]
+
+    def __repr__(self) -> str:
+        return f"BatchFeatureView(name={self.name!r}, features={[f.name for f in self.features]})"
+
+
+# ---------------------------------------------------------------------------
+# StreamFeatureView
+# ---------------------------------------------------------------------------
+
+class StreamFeatureView:
+    """
+    Real-time feature view backed by Kafka → Redis pipeline.
+
+    Analogous to:
+      Feast  — StreamFeatureView
+      Tecton — StreamFeatureView
+
+    Parameters
+    ----------
+    name        : unique view name
+    entities    : list of Entity objects this view joins on
+    features    : list of Feature columns emitted per event
+    source      : DataSource pointing to Kafka topic
+    online      : if True, features are served from Redis online store
+    ttl         : Redis key TTL for online entries
+    tags        : arbitrary key-value metadata
+    description : human-readable description
+    """
+
+    def __init__(
+        self,
+        name: str,
+        entities: List[Entity],
+        features: List[Feature],
+        source: Optional[DataSource] = None,
+        online: bool = True,
+        ttl: datetime.timedelta = datetime.timedelta(hours=24),
+        tags: Optional[dict] = None,
+        description: str = "",
+    ) -> None:
+        self.name = name
+        self.entities = entities
+        self.features = features
+        self.source = source or DataSource.kafka()
+        self.online = online
+        self.ttl = ttl
+        self.tags = tags or {}
+        self.description = description
+        self._transform_fn: Optional[Callable] = None
+
+    @property
+    def join_keys(self) -> List[str]:
+        return [e.join_key for e in self.entities]
+
+    def __repr__(self) -> str:
+        return f"StreamFeatureView(name={self.name!r}, features={[f.name for f in self.features]})"
+
+
+# ---------------------------------------------------------------------------
+# OnDemandFeatureView
+# ---------------------------------------------------------------------------
+
+class OnDemandFeatureView:
+    """
+    Request-time computed features derived from upstream views.
+
+    The transform function receives a merged dict of all upstream feature
+    values and returns a dict of newly computed features.
+
+    Analogous to:
+      Feast  — OnDemandFeatureView
+      Tecton — OnDemandFeatureView
+
+    Parameters
+    ----------
+    name         : unique view name
+    sources      : list of BatchFeatureView / StreamFeatureView to draw inputs from
+    features     : list of Feature columns this view produces
+    transform_fn : callable(inputs: dict) -> dict
+    tags         : arbitrary key-value metadata
+    description  : human-readable description
+    """
+
+    def __init__(
+        self,
+        name: str,
+        sources: List,
+        features: List[Feature],
+        transform_fn: Optional[Callable] = None,
+        tags: Optional[dict] = None,
+        description: str = "",
+    ) -> None:
+        self.name = name
+        self.sources = sources
+        self.features = features
+        self.transform_fn = transform_fn
+        self.tags = tags or {}
+        self.description = description
+
+    def compute(self, inputs: dict) -> dict:
+        """Apply the transformation to merged upstream inputs."""
+        if self.transform_fn is None:
+            return {}
+        return self.transform_fn(inputs)
+
+    def __repr__(self) -> str:
+        return f"OnDemandFeatureView(name={self.name!r}, features={[f.name for f in self.features]})"

--- a/feature-store/materialization.py
+++ b/feature-store/materialization.py
@@ -1,0 +1,125 @@
+"""
+Offline-to-online materialization for StreamForge feature store.
+
+materialize_offline_to_online()
+    Reads a date range from MinIO (offline) and writes latest-per-user
+    snapshots to Redis (online).
+
+push_to_online()
+    Write pre-computed records directly to Redis; used by FeatureStore.push().
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional
+
+# Reach the layout_spec helpers from the existing examples
+_LAYOUT_PATH = Path(__file__).parent.parent / "examples" / "feature-read-paths"
+if str(_LAYOUT_PATH) not in sys.path:
+    sys.path.insert(0, str(_LAYOUT_PATH))
+
+
+def materialize_offline_to_online(
+    offline_reader,
+    online_reader,
+    start_date: datetime.date,
+    end_date: datetime.date,
+    registry,
+    feature_view_names: Optional[List[str]] = None,
+) -> int:
+    """
+    Read offline features for [start_date, end_date] and write the latest
+    snapshot per user to the online store.
+
+    Returns the number of user snapshots written.
+    """
+    if offline_reader is None:
+        print("[materialize] No offline reader — skipping")
+        return 0
+
+    print(f"[materialize] Reading {start_date} → {end_date} from offline store …")
+    t0 = time.perf_counter()
+
+    try:
+        records = offline_reader.read_date_range(start_date, end_date)
+    except Exception as exc:
+        print(f"[materialize] Offline read failed: {exc}")
+        return 0
+
+    print(f"[materialize] Read {len(records):,} records in {time.perf_counter() - t0:.2f}s")
+
+    # Keep only the most-recent window snapshot per user
+    latest_per_user: Dict[int, dict] = {}
+    for r in records:
+        uid = r["user_id"]
+        if uid not in latest_per_user or r["window_start_ms"] > latest_per_user[uid]["window_start_ms"]:
+            latest_per_user[uid] = r
+
+    count = push_to_online(list(latest_per_user.values()), online_reader)
+    print(
+        f"[materialize] Wrote {count} user snapshots to online store "
+        f"({time.perf_counter() - t0:.2f}s total)"
+    )
+    return count
+
+
+def push_to_online(records: List[dict], online_reader) -> int:
+    """
+    Write feature records to Redis.
+
+    Each record must have at minimum: user_id, event_count, window_start_ms.
+    Returns the number of records written (0 when Redis is unavailable).
+    """
+    if online_reader is None:
+        return 0
+
+    redis_client = getattr(online_reader, "_redis", None)
+    if redis_client is None:
+        # Stub backend — update in-memory store directly
+        stub = getattr(online_reader, "_stub", None)
+        if stub is not None:
+            _push_to_stub(records, stub)
+            return len(records)
+        return 0
+
+    from layout_spec import (
+        online_user_key,
+        online_hist_key,
+        ONLINE_USER_TTL,
+        ONLINE_HIST_TTL,
+    )
+
+    now = time.time()
+    pipe = redis_client.pipeline(transaction=False)
+    for r in records:
+        uid = r["user_id"]
+        mapping = {
+            "event_count": str(r.get("event_count", 0)),
+            "window_start_ms": str(r.get("window_start_ms", 0)),
+            "window_end_ms": str(r.get("window_end_ms", r.get("window_start_ms", 0) + 30_000)),
+            "event_rate": str(r.get("event_rate", 0.0)),
+            "updated_at": str(now),
+        }
+        pipe.hset(online_user_key(uid), mapping=mapping)
+        pipe.expire(online_user_key(uid), ONLINE_USER_TTL)
+        pipe.zadd(online_hist_key(uid), {json.dumps(r): r.get("window_start_ms", 0)})
+        pipe.expire(online_hist_key(uid), ONLINE_HIST_TTL)
+
+    pipe.execute()
+    return len(records)
+
+
+def _push_to_stub(records: List[dict], stub) -> None:
+    """Update the in-memory stub store (used when Redis is unavailable)."""
+    now = time.time()
+    for r in records:
+        uid = r["user_id"]
+        entry = dict(r, updated_at=now)
+        stub._latest[uid] = entry
+        hist = stub._history.setdefault(uid, [])
+        hist.append(entry)
+        stub._history[uid] = sorted(hist, key=lambda x: x.get("window_start_ms", 0))

--- a/feature-store/registry.py
+++ b/feature-store/registry.py
@@ -1,0 +1,92 @@
+"""
+In-memory registry for StreamForge feature store objects.
+
+In production (Feast uses SQLite / PostgreSQL / GCS backed registry).
+For StreamForge we use a fast in-memory dict with optional JSON dump.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+from entities import Entity
+from feature_views import BatchFeatureView, StreamFeatureView, OnDemandFeatureView
+from feature_service import FeatureService
+
+FeatureViewType = Union[BatchFeatureView, StreamFeatureView, OnDemandFeatureView]
+
+
+class Registry:
+    """
+    Central registry that tracks entities, feature views, and feature services.
+
+    All apply() calls are idempotent — re-applying with the same name
+    overwrites the previous definition.
+    """
+
+    def __init__(self) -> None:
+        self._entities: Dict[str, Entity] = {}
+        self._feature_views: Dict[str, FeatureViewType] = {}
+        self._feature_services: Dict[str, FeatureService] = {}
+
+    # ------------------------------------------------------------------
+    # Entities
+    # ------------------------------------------------------------------
+
+    def apply_entity(self, entity: Entity) -> None:
+        self._entities[entity.name] = entity
+
+    def get_entity(self, name: str) -> Entity:
+        if name not in self._entities:
+            raise KeyError(f"Entity not found: {name!r}")
+        return self._entities[name]
+
+    def list_entities(self) -> List[Entity]:
+        return list(self._entities.values())
+
+    # ------------------------------------------------------------------
+    # Feature views
+    # ------------------------------------------------------------------
+
+    def apply_feature_view(self, view: FeatureViewType) -> None:
+        self._feature_views[view.name] = view
+
+    def get_feature_view(self, name: str) -> FeatureViewType:
+        if name not in self._feature_views:
+            raise KeyError(f"FeatureView not found: {name!r}")
+        return self._feature_views[name]
+
+    def list_feature_views(self) -> List[FeatureViewType]:
+        return list(self._feature_views.values())
+
+    # ------------------------------------------------------------------
+    # Feature services
+    # ------------------------------------------------------------------
+
+    def apply_feature_service(self, service: FeatureService) -> None:
+        self._feature_services[service.name] = service
+
+    def get_feature_service(self, name: str) -> FeatureService:
+        if name not in self._feature_services:
+            raise KeyError(f"FeatureService not found: {name!r}")
+        return self._feature_services[name]
+
+    def list_feature_services(self) -> List[FeatureService]:
+        return list(self._feature_services.values())
+
+    # ------------------------------------------------------------------
+    # Serialization (for debugging / persistence)
+    # ------------------------------------------------------------------
+
+    def dump(self) -> dict:
+        return {
+            "entities": [e.name for e in self.list_entities()],
+            "feature_views": [v.name for v in self.list_feature_views()],
+            "feature_services": [s.name for s in self.list_feature_services()],
+        }
+
+    def save(self, path: Union[str, Path]) -> None:
+        """Persist registry index to a JSON file."""
+        with open(path, "w") as f:
+            json.dump(self.dump(), f, indent=2)

--- a/feature-store/requirements.txt
+++ b/feature-store/requirements.txt
@@ -1,0 +1,8 @@
+# Runtime — all optional; the store falls back to in-memory stubs when absent
+minio>=7.2.0          # offline store (MinIO / S3-compatible)
+redis>=5.0.0          # online store
+pandas>=2.0.0         # to_df() on FeatureVector / RetrievalJob
+pyarrow>=14.0.0       # to_arrow() on RetrievalJob
+
+# Dev / test
+pytest>=8.0.0

--- a/feature-store/store.py
+++ b/feature-store/store.py
@@ -1,0 +1,526 @@
+"""
+FeatureStore — the main entry point for StreamForge's feature store.
+
+Feast-compatible API surface
+-----------------------------
+  store = FeatureStore(project="streamforge")
+  store.apply([entity, batch_view, stream_view, service])
+
+  # Online serving
+  fv = store.get_online_features(
+      features=["user_event_stats:event_count", "user_event_stats:event_rate"],
+      entity_rows=[{"user_id": 42}, {"user_id": 99}],
+  )
+  fv.to_dict()   # → {"event_count": [12, 7], "event_rate": [0.4, 0.23]}
+  fv.to_df()     # → pandas DataFrame
+
+  # Historical / offline
+  job = store.get_historical_features(
+      entity_df=pd.DataFrame({"user_id": [42, 99], "event_timestamp": [...]}),
+      features=["user_event_stats:event_count"],
+  )
+  df = job.to_df()
+
+  # Materialize offline → online
+  store.materialize(start_date=date(2026, 5, 1), end_date=date(2026, 5, 25))
+
+  # Push stream records
+  store.push("user_event_stats_stream", records, to="online")
+
+Tecton-compatible alias
+-----------------------
+  store.get_features(
+      join_keys={"user_id": [1, 42, 99]},
+      feature_service_name="recommendation_service",
+  )
+"""
+from __future__ import annotations
+
+import datetime
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional, Union
+
+# Expose existing feature-read-paths readers
+_READERS_DIR = Path(__file__).parent.parent / "examples" / "feature-read-paths"
+if str(_READERS_DIR) not in sys.path:
+    sys.path.insert(0, str(_READERS_DIR))
+
+from registry import Registry
+from entities import Entity
+from feature_views import BatchFeatureView, StreamFeatureView, OnDemandFeatureView, Feature
+from feature_service import FeatureService
+
+try:
+    from offline_batch_reader import OfflineBatchReader
+    from online_lowlatency_reader import OnlineFeatureReader
+    _READERS_AVAILABLE = True
+except ImportError:
+    _READERS_AVAILABLE = False
+
+RegistryObject = Union[Entity, BatchFeatureView, StreamFeatureView, OnDemandFeatureView, FeatureService]
+
+
+# ---------------------------------------------------------------------------
+# FeatureVector — result of online serving
+# ---------------------------------------------------------------------------
+
+class FeatureVector:
+    """
+    Result of get_online_features() or get_features().
+
+    Feast-compatible interface: .to_dict() and .to_df().
+    """
+
+    def __init__(self, results: List[dict], feature_names: List[str]) -> None:
+        self._results = results
+        self._feature_names = feature_names
+
+    def to_dict(self) -> Dict[str, list]:
+        """Return {feature_name: [value, ...]} mapping (Feast-style)."""
+        return {name: [r.get(name) for r in self._results] for name in self._feature_names}
+
+    def to_df(self):
+        """Return a pandas DataFrame. Requires pandas."""
+        try:
+            import pandas as pd
+        except ImportError as exc:
+            raise ImportError("pandas is required for to_df()") from exc
+        return pd.DataFrame(self._results)
+
+    def __len__(self) -> int:
+        return len(self._results)
+
+    def __repr__(self) -> str:
+        return f"FeatureVector(rows={len(self._results)}, features={self._feature_names})"
+
+
+# ---------------------------------------------------------------------------
+# RetrievalJob — lazy historical retrieval
+# ---------------------------------------------------------------------------
+
+class RetrievalJob:
+    """
+    Lazy offline / historical feature retrieval.
+
+    Feast-compatible: .to_df(), .to_arrow(), .persist().
+    """
+
+    def __init__(
+        self,
+        entity_df,
+        features: List[str],
+        offline_reader,
+        registry: Registry,
+    ) -> None:
+        self._entity_df = entity_df
+        self._features = features
+        self._offline_reader = offline_reader
+        self._registry = registry
+        self._cached: Optional[list] = None
+
+    # ------------------------------------------------------------------
+    # Materialise
+    # ------------------------------------------------------------------
+
+    def to_df(self):
+        import pandas as pd
+        records = self._fetch()
+        return pd.DataFrame(records) if records else pd.DataFrame()
+
+    def to_arrow(self):
+        try:
+            import pyarrow as pa
+        except ImportError as exc:
+            raise ImportError("pyarrow is required for to_arrow()") from exc
+        return pa.Table.from_pandas(self.to_df())
+
+    def persist(self, destination, allow_overwrite: bool = False) -> None:
+        """Write results to a file path or object with a .write() method."""
+        df = self.to_df()
+        if hasattr(destination, "write"):
+            destination.write(df.to_dict(orient="records"))
+        elif isinstance(destination, (str, Path)):
+            df.to_parquet(str(destination))
+        else:
+            raise ValueError(f"Unsupported destination: {type(destination)}")
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _fetch(self) -> List[dict]:
+        if self._cached is not None:
+            return self._cached
+        if self._offline_reader is None:
+            return []
+
+        entity_data = _normalize_entity_df(self._entity_df)
+        entity_user_ids = set(int(u) for u in entity_data.get("user_id", []))
+
+        timestamps = entity_data.get("event_timestamp", [])
+        if timestamps:
+            try:
+                import pandas as pd
+                ts = pd.to_datetime(timestamps)
+                start = ts.min().date() - datetime.timedelta(days=1)
+                end = ts.max().date()
+            except Exception:
+                end = datetime.date.today()
+                start = end - datetime.timedelta(days=7)
+        else:
+            end = datetime.date.today()
+            start = end - datetime.timedelta(days=7)
+
+        try:
+            records = self._offline_reader.read_date_range(start, end)
+        except Exception:
+            records = []
+
+        filtered = [r for r in records if r.get("user_id") in entity_user_ids]
+        self._cached = filtered
+        return filtered
+
+
+# ---------------------------------------------------------------------------
+# FeatureStore
+# ---------------------------------------------------------------------------
+
+class FeatureStore:
+    """
+    StreamForge FeatureStore — Feast-compatible + Tecton-compatible.
+
+    Wraps the existing offline (MinIO/S3) and online (Redis) readers with
+    a declarative registry of entities, feature views, and feature services.
+
+    Parameters
+    ----------
+    project   : logical project / namespace (used as a metadata label)
+    repo_path : optional path for persisting registry snapshots
+    """
+
+    def __init__(
+        self,
+        project: str = "streamforge",
+        repo_path: Optional[str] = None,
+    ) -> None:
+        self.project = project
+        self.repo_path = Path(repo_path) if repo_path else None
+        self._registry = Registry()
+        self._online_reader: Optional[object] = None
+        self._offline_reader: Optional[object] = None
+        self._init_readers()
+
+    def _init_readers(self) -> None:
+        if not _READERS_AVAILABLE:
+            return
+        try:
+            self._online_reader = OnlineFeatureReader()
+        except Exception:
+            pass
+        try:
+            self._offline_reader = OfflineBatchReader()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Registry operations  (Feast: apply / list_*)
+    # ------------------------------------------------------------------
+
+    def apply(self, objects: List[RegistryObject]) -> None:
+        """Register entities, feature views, and feature services."""
+        for obj in objects:
+            if isinstance(obj, Entity):
+                self._registry.apply_entity(obj)
+            elif isinstance(obj, (BatchFeatureView, StreamFeatureView, OnDemandFeatureView)):
+                self._registry.apply_feature_view(obj)
+            elif isinstance(obj, FeatureService):
+                self._registry.apply_feature_service(obj)
+            else:
+                raise TypeError(f"Cannot apply object of type {type(obj).__name__!r}")
+        if self.repo_path:
+            self._registry.save(self.repo_path / "registry.json")
+
+    def list_entities(self) -> List[Entity]:
+        return self._registry.list_entities()
+
+    def list_feature_views(self) -> List:
+        return self._registry.list_feature_views()
+
+    def list_feature_services(self) -> List[FeatureService]:
+        return self._registry.list_feature_services()
+
+    def get_feature_view(self, name: str):
+        return self._registry.get_feature_view(name)
+
+    def get_feature_service(self, name: str) -> FeatureService:
+        return self._registry.get_feature_service(name)
+
+    # ------------------------------------------------------------------
+    # Online serving  (Feast: get_online_features)
+    # ------------------------------------------------------------------
+
+    def get_online_features(
+        self,
+        features: List[str],
+        entity_rows: List[Dict],
+    ) -> FeatureVector:
+        """
+        Fetch real-time features for a list of entity rows.
+
+        Parameters
+        ----------
+        features : list[str]
+            Feature references — "view_name:feature_name" or "view_name:*".
+        entity_rows : list[dict]
+            Each dict must include the join key, e.g. {"user_id": 42}.
+
+        Returns
+        -------
+        FeatureVector
+        """
+        parsed_refs = _parse_feature_refs(features, self._registry)
+        feature_names = list(dict.fromkeys(fn for _, fn in parsed_refs))  # preserve order, dedupe
+
+        user_ids = [int(row["user_id"]) for row in entity_rows if "user_id" in row]
+        raw_batch: Dict[int, dict] = {}
+        if self._online_reader and user_ids:
+            try:
+                raw_batch = self._online_reader.get_batch(user_ids)
+            except Exception:
+                pass
+
+        results = []
+        for row in entity_rows:
+            uid = row.get("user_id")
+            feat_data = raw_batch.get(int(uid), {}) if uid is not None else {}
+            results.append({**row, **feat_data})
+
+        # Apply OnDemandFeatureView transforms
+        results = self._apply_on_demand_transforms(results, parsed_refs)
+
+        return FeatureVector(results, feature_names)
+
+    def _apply_on_demand_transforms(
+        self, results: List[dict], parsed_refs: List[tuple]
+    ) -> List[dict]:
+        """Run any OnDemandFeatureView transforms requested in the feature refs."""
+        on_demand_views = {
+            name: self._registry.get_feature_view(name)
+            for name, _ in parsed_refs
+            if name and name in {v.name for v in self._registry.list_feature_views()}
+            and isinstance(self._registry.get_feature_view(name), OnDemandFeatureView)
+        }
+        if not on_demand_views:
+            return results
+        return [
+            {**row, **{view.name: view.compute(row) for view in on_demand_views.values()}}
+            for row in results
+        ]
+
+    # ------------------------------------------------------------------
+    # Tecton-compatible alias
+    # ------------------------------------------------------------------
+
+    def get_features(
+        self,
+        join_keys: Dict[str, List],
+        feature_service_name: str,
+    ) -> FeatureVector:
+        """
+        Tecton-compatible get_features().
+
+        Parameters
+        ----------
+        join_keys : dict[str, list]
+            e.g. {"user_id": [1, 42, 99]}
+        feature_service_name : str
+            Name of a registered FeatureService.
+        """
+        service = self._registry.get_feature_service(feature_service_name)
+        feature_refs = [
+            f"{view.name}:*"
+            for view in service.features
+        ]
+        key_names = list(join_keys.keys())
+        key_values = list(join_keys.values())
+        entity_rows = [
+            dict(zip(key_names, row_vals))
+            for row_vals in zip(*key_values)
+        ]
+        return self.get_online_features(feature_refs, entity_rows)
+
+    # ------------------------------------------------------------------
+    # Historical / offline retrieval  (Feast: get_historical_features)
+    # ------------------------------------------------------------------
+
+    def get_historical_features(
+        self,
+        entity_df,
+        features: List[str],
+        full_feature_names: bool = False,
+    ) -> RetrievalJob:
+        """
+        Lazy historical feature retrieval from the offline store.
+
+        Parameters
+        ----------
+        entity_df : pd.DataFrame or dict-of-lists
+            Must contain join key column (e.g. "user_id") and optionally
+            "event_timestamp" for point-in-time correct lookups.
+        features : list[str]
+            Feature references in "view_name:feature_name" format.
+
+        Returns
+        -------
+        RetrievalJob
+            Call .to_df() to materialise results.
+        """
+        return RetrievalJob(entity_df, features, self._offline_reader, self._registry)
+
+    # ------------------------------------------------------------------
+    # Materialization  (Feast: materialize / materialize_incremental)
+    # ------------------------------------------------------------------
+
+    def materialize(
+        self,
+        start_date: datetime.date,
+        end_date: datetime.date,
+        feature_views: Optional[List[str]] = None,
+    ) -> None:
+        """
+        Read offline features for [start_date, end_date] and push to online store.
+
+        Parameters
+        ----------
+        start_date, end_date : datetime.date
+            Inclusive date range.
+        feature_views : list[str] | None
+            Restrict to named views; None = all registered batch views.
+        """
+        from materialization import materialize_offline_to_online
+        materialize_offline_to_online(
+            offline_reader=self._offline_reader,
+            online_reader=self._online_reader,
+            start_date=start_date,
+            end_date=end_date,
+            registry=self._registry,
+            feature_view_names=feature_views,
+        )
+
+    def materialize_incremental(
+        self,
+        end_date: datetime.date,
+        feature_views: Optional[List[str]] = None,
+    ) -> None:
+        """Materialize the last 24 hours up to end_date."""
+        start_date = end_date - datetime.timedelta(days=1)
+        self.materialize(start_date, end_date, feature_views)
+
+    # ------------------------------------------------------------------
+    # Push (stream ingest)  (Feast: push)
+    # ------------------------------------------------------------------
+
+    def push(
+        self,
+        feature_view_name: str,
+        df,
+        to: str = "online",
+    ) -> None:
+        """
+        Push externally computed feature values into the store.
+
+        Parameters
+        ----------
+        feature_view_name : str
+            Must match a registered StreamFeatureView name.
+        df : pd.DataFrame or list[dict]
+        to : "online" (Redis) — offline push not yet supported
+        """
+        from materialization import push_to_online
+        records = _df_to_records(df)
+        if to == "online":
+            pushed = push_to_online(records, self._online_reader)
+            print(f"[push] Wrote {pushed} records to online store for {feature_view_name!r}")
+        else:
+            raise ValueError(f"push(to={to!r}) is not supported")
+
+    # ------------------------------------------------------------------
+    # Diagnostics
+    # ------------------------------------------------------------------
+
+    def stats(self) -> dict:
+        online_stats = {}
+        if self._online_reader:
+            try:
+                online_stats = self._online_reader.stats()
+            except Exception:
+                pass
+        return {
+            "project": self.project,
+            "registry": self._registry.dump(),
+            "online_store": online_stats,
+            "offline_store": {
+                "available": self._offline_reader is not None
+                and getattr(self._offline_reader, "is_live", False)
+            },
+        }
+
+    def __repr__(self) -> str:
+        reg = self._registry.dump()
+        return (
+            f"FeatureStore(project={self.project!r}, "
+            f"entities={reg['entities']}, "
+            f"views={reg['feature_views']}, "
+            f"services={reg['feature_services']})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _parse_feature_refs(
+    features: List[str], registry: Registry
+) -> List[tuple]:
+    """Parse "view:feature" refs → list of (view_name, feature_name)."""
+    parsed = []
+    for ref in features:
+        if ref == "*":
+            for view in registry.list_feature_views():
+                for f in view.features:
+                    parsed.append((view.name, f.name))
+        elif ":" in ref:
+            view_name, feat_name = ref.rsplit(":", 1)
+            if feat_name == "*":
+                try:
+                    view = registry.get_feature_view(view_name)
+                    for f in view.features:
+                        parsed.append((view_name, f.name))
+                except KeyError:
+                    pass
+            else:
+                parsed.append((view_name, feat_name))
+        else:
+            parsed.append(("", ref))
+    return parsed
+
+
+def _normalize_entity_df(entity_df) -> dict:
+    """Coerce entity_df (DataFrame or dict) to a plain dict of lists."""
+    if isinstance(entity_df, dict):
+        return entity_df
+    try:
+        return entity_df.to_dict(orient="list")
+    except AttributeError:
+        return {}
+
+
+def _df_to_records(df) -> List[dict]:
+    """Convert DataFrame or list[dict] to list[dict]."""
+    if isinstance(df, list):
+        return df
+    try:
+        return df.to_dict(orient="records")
+    except AttributeError:
+        return list(df)

--- a/feature-store/tecton_compat.py
+++ b/feature-store/tecton_compat.py
@@ -1,0 +1,188 @@
+"""
+Tecton-compatible decorator API for defining feature views.
+
+This module provides decorators that mirror Tecton's Python SDK surface,
+layering cleanly on top of StreamForge's core primitives.
+
+Usage
+-----
+    import datetime
+    from feature_store.tecton_compat import (
+        batch_feature_view,
+        stream_feature_view,
+        on_demand_feature_view,
+    )
+    from feature_store.entities import Entity
+    from feature_store.feature_views import Feature, DataSource
+
+    user = Entity(name="user", join_key="user_id")
+
+    @batch_feature_view(
+        sources=[DataSource.minio()],
+        entities=[user],
+        online=True,
+        offline=True,
+        ttl=datetime.timedelta(days=7),
+        description="Per-user event statistics computed by StreamForge Flink job",
+    )
+    def user_event_stats(records):
+        # records is list[dict] from the offline store
+        return records  # pass-through; add transformations here
+
+    @stream_feature_view(
+        source=DataSource.kafka(topic="user.event.counts"),
+        entities=[user],
+        features=[Feature.float("event_rate")],
+    )
+    def realtime_event_rate(event):
+        return {"event_rate": event.get("event_count", 0) / 30.0}
+
+    @on_demand_feature_view(
+        sources=[user_event_stats],
+        features=[Feature.float("event_rate_normalized")],
+    )
+    def normalized_event_rate(inputs):
+        return {"event_rate_normalized": min(inputs.get("event_rate", 0.0) / 10.0, 1.0)}
+"""
+from __future__ import annotations
+
+import datetime
+import functools
+from typing import Callable, List, Optional
+
+from feature_views import (
+    BatchFeatureView,
+    StreamFeatureView,
+    OnDemandFeatureView,
+    Feature,
+    DataSource,
+)
+from entities import Entity
+
+
+# ---------------------------------------------------------------------------
+# Decorators
+# ---------------------------------------------------------------------------
+
+def batch_feature_view(
+    sources: List,
+    entities: List[Entity],
+    features: Optional[List[Feature]] = None,
+    online: bool = True,
+    offline: bool = True,
+    ttl: datetime.timedelta = datetime.timedelta(days=7),
+    description: str = "",
+    tags: Optional[dict] = None,
+    mode: str = "python",
+    feature_start_time: Optional[datetime.datetime] = None,
+) -> Callable:
+    """
+    Decorator — turns a Python function into a Tecton-style BatchFeatureView.
+
+    The decorated function receives raw offline records (list[dict]) and
+    should return transformed records (list[dict]).  The function name
+    becomes the view name.
+
+    Parameters mirror Tecton's @batch_feature_view:
+      sources            — list of DataSource objects (first is used)
+      entities           — list of Entity this view is keyed on
+      features           — list of Feature columns (inferred from fn if omitted)
+      online / offline   — materialization targets
+      ttl                — how long online cache entries stay valid
+      mode               — "python" (default); reserved for future Spark/PySpark
+      feature_start_time — earliest timestamp the view covers (metadata only)
+    """
+    def decorator(fn: Callable) -> BatchFeatureView:
+        view_features = features or []
+        source = sources[0] if sources else DataSource.minio()
+        view = BatchFeatureView(
+            name=fn.__name__,
+            entities=entities,
+            features=view_features,
+            source=source,
+            ttl=ttl,
+            online=online,
+            tags=tags or {},
+            description=description or (fn.__doc__ or "").strip(),
+        )
+        view._transform_fn = fn
+        functools.update_wrapper(view, fn)
+        return view
+
+    return decorator
+
+
+def stream_feature_view(
+    source: Optional[DataSource] = None,
+    entities: Optional[List[Entity]] = None,
+    features: Optional[List[Feature]] = None,
+    online: bool = True,
+    ttl: datetime.timedelta = datetime.timedelta(hours=24),
+    description: str = "",
+    tags: Optional[dict] = None,
+    mode: str = "python",
+) -> Callable:
+    """
+    Decorator — turns a Python function into a Tecton-style StreamFeatureView.
+
+    The decorated function receives a single Kafka event record (dict) and
+    should return a dict of computed feature values.
+
+    Parameters mirror Tecton's @stream_feature_view:
+      source   — DataSource.kafka(...)
+      entities — list of Entity this view is keyed on
+      features — list of Feature columns produced per event
+      online   — if True, events are written to online store via push()
+      ttl      — Redis key TTL for online entries
+      mode     — "python" (default)
+    """
+    def decorator(fn: Callable) -> StreamFeatureView:
+        view_features = features or []
+        view = StreamFeatureView(
+            name=fn.__name__,
+            entities=entities or [],
+            features=view_features,
+            source=source or DataSource.kafka(),
+            online=online,
+            ttl=ttl,
+            tags=tags or {},
+            description=description or (fn.__doc__ or "").strip(),
+        )
+        view._transform_fn = fn
+        functools.update_wrapper(view, fn)
+        return view
+
+    return decorator
+
+
+def on_demand_feature_view(
+    sources: List,
+    features: List[Feature],
+    mode: str = "python",
+    description: str = "",
+    tags: Optional[dict] = None,
+) -> Callable:
+    """
+    Decorator — turns a Python function into a Tecton-style OnDemandFeatureView.
+
+    The decorated function receives a merged dict of all upstream feature
+    values and should return a dict of newly computed features.
+
+    Parameters mirror Tecton's @on_demand_feature_view:
+      sources  — list of BatchFeatureView / StreamFeatureView to pull inputs from
+      features — list of Feature columns this view produces
+      mode     — "python" (default)
+    """
+    def decorator(fn: Callable) -> OnDemandFeatureView:
+        view = OnDemandFeatureView(
+            name=fn.__name__,
+            sources=sources,
+            features=features,
+            transform_fn=fn,
+            tags=tags or {},
+            description=description or (fn.__doc__ or "").strip(),
+        )
+        functools.update_wrapper(view, fn)
+        return view
+
+    return decorator

--- a/feature-store/tests.py
+++ b/feature-store/tests.py
@@ -1,0 +1,407 @@
+"""
+Unit tests for the StreamForge feature store (no external services required).
+
+Run:
+    cd feature-store
+    python -m pytest tests.py -v
+"""
+from __future__ import annotations
+
+import datetime
+import sys
+from pathlib import Path
+
+import pytest
+
+# Make the feature-store package importable
+sys.path.insert(0, str(Path(__file__).parent))
+
+from entities import Entity, ValueType
+from feature_views import BatchFeatureView, StreamFeatureView, OnDemandFeatureView, Feature, DataSource
+from feature_service import FeatureService
+from registry import Registry
+from store import FeatureStore, FeatureVector, _parse_feature_refs
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def user_entity():
+    return Entity(name="user", join_key="user_id")
+
+
+@pytest.fixture
+def batch_view(user_entity):
+    return BatchFeatureView(
+        name="user_event_stats",
+        entities=[user_entity],
+        features=[Feature.int("event_count"), Feature.float("event_rate")],
+        source=DataSource.minio(),
+    )
+
+
+@pytest.fixture
+def stream_view(user_entity):
+    return StreamFeatureView(
+        name="realtime_events",
+        entities=[user_entity],
+        features=[Feature.float("event_rate")],
+        source=DataSource.kafka(),
+    )
+
+
+@pytest.fixture
+def on_demand_view(batch_view):
+    return OnDemandFeatureView(
+        name="normalized_rate",
+        sources=[batch_view],
+        features=[Feature.float("event_rate_normalized")],
+        transform_fn=lambda inputs: {
+            "event_rate_normalized": min(inputs.get("event_rate", 0.0) / 10.0, 1.0)
+        },
+    )
+
+
+@pytest.fixture
+def feature_service(batch_view, stream_view):
+    return FeatureService(
+        name="recommendation_service",
+        features=[batch_view, stream_view],
+    )
+
+
+@pytest.fixture
+def store(user_entity, batch_view, stream_view, on_demand_view, feature_service):
+    s = FeatureStore(project="test")
+    s.apply([user_entity, batch_view, stream_view, on_demand_view, feature_service])
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Entity tests
+# ---------------------------------------------------------------------------
+
+class TestEntity:
+    def test_defaults(self, user_entity):
+        assert user_entity.name == "user"
+        assert user_entity.join_key == "user_id"
+        assert user_entity.value_type == ValueType.INT64
+
+    def test_repr(self, user_entity):
+        assert "user" in repr(user_entity)
+
+
+# ---------------------------------------------------------------------------
+# Feature tests
+# ---------------------------------------------------------------------------
+
+class TestFeature:
+    def test_int(self):
+        f = Feature.int("event_count")
+        assert f.dtype == "INT64"
+        assert f.name == "event_count"
+
+    def test_float(self):
+        f = Feature.float("event_rate")
+        assert f.dtype == "FLOAT"
+
+    def test_string(self):
+        f = Feature.string("country")
+        assert f.dtype == "STRING"
+
+
+# ---------------------------------------------------------------------------
+# DataSource tests
+# ---------------------------------------------------------------------------
+
+class TestDataSource:
+    def test_minio_defaults(self):
+        ds = DataSource.minio()
+        assert ds.source_type == "minio"
+        assert ds.config["bucket"] == "processed"
+
+    def test_redis_defaults(self):
+        ds = DataSource.redis()
+        assert ds.source_type == "redis"
+        assert ds.config["port"] == 6379
+
+    def test_kafka_defaults(self):
+        ds = DataSource.kafka()
+        assert ds.source_type == "kafka"
+        assert "user.event.counts" in ds.config["topic"]
+
+    def test_iceberg(self):
+        ds = DataSource.iceberg()
+        assert ds.source_type == "iceberg"
+
+
+# ---------------------------------------------------------------------------
+# FeatureView tests
+# ---------------------------------------------------------------------------
+
+class TestBatchFeatureView:
+    def test_join_keys(self, batch_view, user_entity):
+        assert batch_view.join_keys == ["user_id"]
+
+    def test_repr(self, batch_view):
+        assert "user_event_stats" in repr(batch_view)
+        assert "event_count" in repr(batch_view)
+
+    def test_default_source_is_minio(self, user_entity):
+        view = BatchFeatureView(
+            name="v", entities=[user_entity], features=[Feature.int("x")]
+        )
+        assert view.source.source_type == "minio"
+
+
+class TestStreamFeatureView:
+    def test_join_keys(self, stream_view, user_entity):
+        assert stream_view.join_keys == ["user_id"]
+
+    def test_default_source_is_kafka(self, user_entity):
+        view = StreamFeatureView(
+            name="s", entities=[user_entity], features=[Feature.float("rate")]
+        )
+        assert view.source.source_type == "kafka"
+
+
+class TestOnDemandFeatureView:
+    def test_compute(self, on_demand_view):
+        result = on_demand_view.compute({"event_rate": 5.0})
+        assert "event_rate_normalized" in result
+        assert result["event_rate_normalized"] == pytest.approx(0.5)
+
+    def test_compute_clamps_at_one(self, on_demand_view):
+        result = on_demand_view.compute({"event_rate": 100.0})
+        assert result["event_rate_normalized"] == pytest.approx(1.0)
+
+    def test_compute_no_transform_returns_empty(self, batch_view):
+        view = OnDemandFeatureView(name="v", sources=[batch_view], features=[])
+        assert view.compute({"x": 1}) == {}
+
+
+# ---------------------------------------------------------------------------
+# FeatureService tests
+# ---------------------------------------------------------------------------
+
+class TestFeatureService:
+    def test_feature_view_names(self, feature_service):
+        names = feature_service.feature_view_names
+        assert "user_event_stats" in names
+        assert "realtime_events" in names
+
+    def test_repr(self, feature_service):
+        assert "recommendation_service" in repr(feature_service)
+
+
+# ---------------------------------------------------------------------------
+# Registry tests
+# ---------------------------------------------------------------------------
+
+class TestRegistry:
+    def test_apply_and_get_entity(self, user_entity):
+        reg = Registry()
+        reg.apply_entity(user_entity)
+        assert reg.get_entity("user") is user_entity
+
+    def test_missing_entity_raises(self):
+        reg = Registry()
+        with pytest.raises(KeyError):
+            reg.get_entity("missing")
+
+    def test_apply_and_get_feature_view(self, batch_view):
+        reg = Registry()
+        reg.apply_feature_view(batch_view)
+        assert reg.get_feature_view("user_event_stats") is batch_view
+
+    def test_missing_feature_view_raises(self):
+        reg = Registry()
+        with pytest.raises(KeyError):
+            reg.get_feature_view("ghost")
+
+    def test_apply_and_get_feature_service(self, feature_service):
+        reg = Registry()
+        reg.apply_feature_service(feature_service)
+        assert reg.get_feature_service("recommendation_service") is feature_service
+
+    def test_dump_structure(self, user_entity, batch_view, feature_service):
+        reg = Registry()
+        reg.apply_entity(user_entity)
+        reg.apply_feature_view(batch_view)
+        reg.apply_feature_service(feature_service)
+        d = reg.dump()
+        assert "entities" in d
+        assert "feature_views" in d
+        assert "feature_services" in d
+
+    def test_idempotent_apply(self, user_entity):
+        reg = Registry()
+        reg.apply_entity(user_entity)
+        reg.apply_entity(user_entity)
+        assert len(reg.list_entities()) == 1
+
+
+# ---------------------------------------------------------------------------
+# FeatureStore tests
+# ---------------------------------------------------------------------------
+
+class TestFeatureStore:
+    def test_repr_contains_project(self, store):
+        assert "test" in repr(store)
+
+    def test_apply_registers_objects(self, store):
+        assert any(e.name == "user" for e in store.list_entities())
+        assert any(v.name == "user_event_stats" for v in store.list_feature_views())
+        assert any(s.name == "recommendation_service" for s in store.list_feature_services())
+
+    def test_apply_unknown_type_raises(self):
+        s = FeatureStore(project="x")
+        with pytest.raises(TypeError):
+            s.apply(["not-a-valid-object"])
+
+    def test_get_online_features_returns_feature_vector(self, store):
+        fv = store.get_online_features(
+            features=["user_event_stats:event_count", "user_event_stats:event_rate"],
+            entity_rows=[{"user_id": 1}, {"user_id": 42}],
+        )
+        assert isinstance(fv, FeatureVector)
+        assert len(fv) == 2
+
+    def test_feature_vector_to_dict_has_all_features(self, store):
+        fv = store.get_online_features(
+            features=["user_event_stats:event_count"],
+            entity_rows=[{"user_id": 1}],
+        )
+        d = fv.to_dict()
+        assert "event_count" in d
+        assert len(d["event_count"]) == 1
+
+    def test_get_online_features_wildcard(self, store):
+        fv = store.get_online_features(
+            features=["user_event_stats:*"],
+            entity_rows=[{"user_id": 42}],
+        )
+        d = fv.to_dict()
+        assert "event_count" in d
+        assert "event_rate" in d
+
+    def test_get_features_tecton_alias(self, store):
+        fv = store.get_features(
+            join_keys={"user_id": [1, 42, 99]},
+            feature_service_name="recommendation_service",
+        )
+        assert isinstance(fv, FeatureVector)
+        assert len(fv) == 3
+
+    def test_get_features_unknown_service_raises(self, store):
+        with pytest.raises(KeyError):
+            store.get_features(join_keys={"user_id": [1]}, feature_service_name="ghost")
+
+    def test_get_historical_features_returns_retrieval_job(self, store):
+        from store import RetrievalJob
+        job = store.get_historical_features(
+            entity_df={"user_id": [1, 42]},
+            features=["user_event_stats:event_count"],
+        )
+        assert isinstance(job, RetrievalJob)
+
+    def test_stats_has_expected_keys(self, store):
+        stats = store.stats()
+        assert "project" in stats
+        assert "registry" in stats
+        assert "online_store" in stats
+        assert "offline_store" in stats
+
+
+# ---------------------------------------------------------------------------
+# Feature reference parsing
+# ---------------------------------------------------------------------------
+
+class TestParseFeatureRefs:
+    def test_view_colon_feature(self, store):
+        parsed = _parse_feature_refs(["user_event_stats:event_count"], store._registry)
+        assert ("user_event_stats", "event_count") in parsed
+
+    def test_wildcard_expands_all_features(self, store):
+        parsed = _parse_feature_refs(["user_event_stats:*"], store._registry)
+        names = [fn for _, fn in parsed]
+        assert "event_count" in names
+        assert "event_rate" in names
+
+    def test_global_wildcard(self, store):
+        parsed = _parse_feature_refs(["*"], store._registry)
+        assert len(parsed) > 0
+
+    def test_bare_feature_name(self, store):
+        parsed = _parse_feature_refs(["event_count"], store._registry)
+        assert ("", "event_count") in parsed
+
+
+# ---------------------------------------------------------------------------
+# Tecton decorator API
+# ---------------------------------------------------------------------------
+
+class TestTectonCompat:
+    def test_batch_feature_view_decorator(self, user_entity):
+        from tecton_compat import batch_feature_view
+
+        @batch_feature_view(
+            sources=[DataSource.minio()],
+            entities=[user_entity],
+            features=[Feature.int("event_count")],
+        )
+        def my_batch_view(records):
+            return records
+
+        assert isinstance(my_batch_view, BatchFeatureView)
+        assert my_batch_view.name == "my_batch_view"
+        assert my_batch_view._transform_fn is not None
+
+    def test_stream_feature_view_decorator(self, user_entity):
+        from tecton_compat import stream_feature_view
+
+        @stream_feature_view(
+            source=DataSource.kafka(),
+            entities=[user_entity],
+            features=[Feature.float("rate")],
+        )
+        def my_stream_view(event):
+            return {"rate": event.get("count", 0) / 30.0}
+
+        assert isinstance(my_stream_view, StreamFeatureView)
+        assert my_stream_view.name == "my_stream_view"
+
+    def test_on_demand_feature_view_decorator(self, batch_view):
+        from tecton_compat import on_demand_feature_view
+
+        @on_demand_feature_view(
+            sources=[batch_view],
+            features=[Feature.float("normalized")],
+        )
+        def my_odv(inputs):
+            return {"normalized": inputs.get("event_rate", 0.0) / 10.0}
+
+        assert isinstance(my_odv, OnDemandFeatureView)
+        result = my_odv.compute({"event_rate": 5.0})
+        assert result["normalized"] == pytest.approx(0.5)
+
+    def test_decorated_view_registered_in_store(self, user_entity):
+        from tecton_compat import batch_feature_view
+
+        @batch_feature_view(
+            sources=[DataSource.minio()],
+            entities=[user_entity],
+            features=[Feature.int("count")],
+        )
+        def decorated_stats(records):
+            return records
+
+        s = FeatureStore(project="tecton-test")
+        s.apply([user_entity, decorated_stats])
+        assert s.get_feature_view("decorated_stats") is decorated_stats
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Adds a new `feature-store/` package that layers a declarative registry and dual-framework serving API on top of the existing StreamForge MinIO (offline) and Redis (online) infrastructure.

Feast-compatible surface
- Entity, Feature, DataSource descriptors
- BatchFeatureView (MinIO/Iceberg), StreamFeatureView (Kafka→Redis), OnDemandFeatureView (request-time transforms)
- FeatureService for grouping views into a serving unit
- FeatureStore.apply() / get_online_features() / get_historical_features() / materialize() / materialize_incremental() / push()
- FeatureVector with .to_dict() and .to_df() (Feast-style result)
- RetrievalJob with .to_df() / .to_arrow() / .persist() for offline reads

Tecton-compatible surface
- @batch_feature_view / @stream_feature_view / @on_demand_feature_view decorator API in tecton_compat.py
- FeatureStore.get_features(join_keys, feature_service_name) alias

Supporting modules
- registry.py   – in-memory entity/view/service registry with JSON dump
- materialization.py – offline→online materialization + push_to_online()
- tests.py      – 40 pytest unit tests (no external services required)
- demo.py       – end-to-end walkthrough of both APIs
- requirements.txt – optional deps (minio, redis, pandas, pyarrow)

All runtime deps are optional; the store falls back to the existing InMemoryOnlineStore stub and synthetic offline records when MinIO/Redis are not reachable, so the demo and tests always run without Docker.