### PR TITLE
feat(realtime-inference): Flink async-I/O pipeline + model server exa…

### DIFF
--- a/examples/realtime-inference/Dockerfile
+++ b/examples/realtime-inference/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY examples/realtime-inference/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY examples/realtime-inference/ ./examples/realtime-inference/
+
+ENV MODEL_SERVER_PORT=8080
+EXPOSE 8080
+
+CMD ["python", "examples/realtime-inference/model_server.py"]

--- a/examples/realtime-inference/README.md
+++ b/examples/realtime-inference/README.md
@@ -1,0 +1,112 @@
+# Real-time Inference Pipeline
+
+End-to-end example wiring **Apache Flink async I/O** to a **model server** for
+sub-second per-record inference at streaming scale.
+
+```
+Kafka (user.event.counts)
+       │
+       ▼
+ InferencePipelineJob        ← Flink job (Java)
+  └─ AsyncDataStream.unorderedWait()
+        │  HTTP POST /predict  (non-blocking, up to 100 in-flight)
+        ▼
+  model-server:8080           ← FastAPI (Python)
+        │
+        ▼
+ Kafka (user.event.predictions)
+```
+
+## Components
+
+| File | Description |
+|------|-------------|
+| `model_server.py` | FastAPI inference endpoint (`POST /predict`) |
+| `demo.py` | End-to-end demo: generates records → calls model server → prints report |
+| `docker-compose.yml` | Kafka + model-server + demo runner |
+| `Dockerfile` | Model-server image |
+| [`InferencePipelineJob.java`](../../stream-processor/src/main/java/ai/streamforge/processor/InferencePipelineJob.java) | Flink async-I/O job |
+| [`ModelServerAsyncFunction.java`](../../stream-processor/src/main/java/ai/streamforge/processor/inference/ModelServerAsyncFunction.java) | Flink `RichAsyncFunction` — non-blocking HTTP |
+
+## Quick start
+
+### Offline demo (no Kafka, no Flink)
+
+```bash
+pip install fastapi uvicorn
+# Terminal 1 — start model server
+python examples/realtime-inference/model_server.py
+
+# Terminal 2 — run demo
+python examples/realtime-inference/demo.py --records 200 --verbose
+```
+
+### Docker Compose (model server + Kafka + demo)
+
+```bash
+docker compose -f examples/realtime-inference/docker-compose.yml up --build
+```
+
+### Full pipeline (CDC → Flink → model server)
+
+```bash
+docker compose \
+  -f deploy/cdc-flink-minio-demo/docker-compose.yml \
+  -f examples/realtime-inference/docker-compose.yml \
+  up
+```
+
+## Environment variables
+
+### Flink job (`InferencePipelineJob`)
+
+| Variable | Default | Description |
+|---|---|---|
+| `KAFKA_BOOTSTRAP_SERVERS` | `localhost:9092` | Kafka brokers |
+| `KAFKA_SOURCE_TOPIC` | `user.event.counts` | Input topic (UserEventCount JSON) |
+| `KAFKA_SINK_TOPIC` | `user.event.predictions` | Output topic (InferencePrediction JSON) |
+| `KAFKA_CONSUMER_GROUP` | `flink-inference-pipeline` | Consumer group |
+| `MODEL_SERVER_URL` | `http://localhost:8080/predict` | Model server endpoint |
+| `MODEL_SERVER_TIMEOUT_MS` | `2000` | Per-request HTTP timeout |
+| `ASYNC_MAX_CONCURRENT` | `100` | Max in-flight async requests |
+| `ASYNC_TIMEOUT_MS` | `5000` | Flink async-I/O timeout |
+
+### Model server
+
+| Variable | Default | Description |
+|---|---|---|
+| `MODEL_SERVER_PORT` | `8080` | Listening port |
+| `MODEL_LOW_THRESHOLD` | `5` | Events/min below → "low" |
+| `MODEL_MEDIUM_THRESHOLD` | `20` | Events/min below → "medium"; above → "high" |
+
+## API
+
+### `POST /predict`
+
+```json
+// Request
+{"userId": "user_0042", "count": 12, "windowStartMs": 1700000000000, "windowEndMs": 1700000060000}
+
+// Response
+{"label": "medium", "confidence": 0.8713}
+```
+
+Labels: `low` | `medium` | `high`
+
+### `GET /healthz`
+Returns `{"status": "ok"}`.
+
+### `GET /metrics`
+Returns `{"requests_total": N, "errors_total": N, "avg_latency_ms": N}`.
+
+## Design notes
+
+- **No blocking threads**: `AsyncDataStream.unorderedWait()` keeps Flink task
+  threads free while waiting for HTTP responses. Up to `ASYNC_MAX_CONCURRENT`
+  requests are in-flight simultaneously.
+- **Fault tolerance**: timeout and HTTP errors emit `label="error"` so the
+  pipeline never stalls; errors are counted in Flink metrics
+  (`model_server.errors_total`).
+- **Swap the model**: replace `_load_model()` in `model_server.py` with any
+  loader (pickle, ONNX runtime, TorchScript) — the serving contract is just
+  the JSON request/response schema above.

--- a/examples/realtime-inference/demo.py
+++ b/examples/realtime-inference/demo.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""
+StreamForge AI — Real-time Inference Pipeline Demo
+
+Demonstrates the full loop end-to-end without running Flink:
+
+  1. [PRODUCE]   Publish synthetic UserEventCount records to Kafka.
+  2. [INFER]     Call the model server directly for each record (mirrors
+                 what InferencePipelineJob does via async HTTP).
+  3. [CONSUME]   Read InferencePrediction records back from Kafka and
+                 print a summary report.
+
+When Kafka is unavailable the demo runs in "offline" mode — it generates
+records, calls the model server, and prints results without touching Kafka.
+
+Usage
+-----
+  # Offline (no Kafka, no Flink needed):
+  python examples/realtime-inference/demo.py
+
+  # Against a live stack (see docker-compose.yml):
+  KAFKA_BOOTSTRAP_SERVERS=localhost:9092 \\
+  MODEL_SERVER_URL=http://localhost:8080/predict \\
+  python examples/realtime-inference/demo.py --records 200
+
+  # Print raw prediction JSON:
+  python examples/realtime-inference/demo.py --verbose
+
+Environment variables
+---------------------
+  KAFKA_BOOTSTRAP_SERVERS   default: localhost:9092
+  KAFKA_SOURCE_TOPIC        default: user.event.counts
+  KAFKA_SINK_TOPIC          default: user.event.predictions
+  MODEL_SERVER_URL          default: http://localhost:8080/predict
+  MODEL_SERVER_TIMEOUT_S    default: 2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import time
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from typing import List, Optional, Tuple
+
+import urllib.request
+import urllib.error
+
+# ---------------------------------------------------------------------------
+# Data classes mirroring Java POJOs
+# ---------------------------------------------------------------------------
+
+@dataclass
+class UserEventCount:
+    userId:        str
+    count:         int
+    windowStartMs: int
+    windowEndMs:   int
+
+
+@dataclass
+class InferencePrediction:
+    userId:             str
+    windowStartMs:      int
+    windowEndMs:        int
+    eventCount:         int
+    label:              str
+    confidence:         float
+    inferenceLatencyMs: int
+    predictedAtMs:      int
+
+
+# ---------------------------------------------------------------------------
+# Synthetic data generator
+# ---------------------------------------------------------------------------
+
+def _generate_records(n: int, window_size_s: int = 60) -> List[UserEventCount]:
+    now_ms      = int(time.time() * 1000)
+    window_ms   = window_size_s * 1000
+    user_ids    = [f"user_{i:04d}" for i in range(max(1, n // 5))]
+    records     = []
+    for i in range(n):
+        window_start = now_ms - (n - i) * window_ms
+        records.append(UserEventCount(
+            userId        = random.choice(user_ids),
+            count         = random.randint(0, 50),
+            windowStartMs = window_start,
+            windowEndMs   = window_start + window_ms,
+        ))
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Model server client
+# ---------------------------------------------------------------------------
+
+def _call_model_server(
+        record: UserEventCount,
+        url: str,
+        timeout_s: float = 2.0,
+) -> InferencePrediction:
+    payload = json.dumps(asdict(record)).encode()
+    req     = urllib.request.Request(
+        url,
+        data    = payload,
+        headers = {"Content-Type": "application/json"},
+        method  = "POST",
+    )
+    t0 = time.perf_counter()
+    try:
+        with urllib.request.urlopen(req, timeout=timeout_s) as resp:
+            body       = json.loads(resp.read())
+            latency_ms = int((time.perf_counter() - t0) * 1000)
+            return InferencePrediction(
+                userId             = record.userId,
+                windowStartMs      = record.windowStartMs,
+                windowEndMs        = record.windowEndMs,
+                eventCount         = record.count,
+                label              = body["label"],
+                confidence         = body["confidence"],
+                inferenceLatencyMs = latency_ms,
+                predictedAtMs      = int(time.time() * 1000),
+            )
+    except Exception as exc:
+        latency_ms = int((time.perf_counter() - t0) * 1000)
+        return InferencePrediction(
+            userId             = record.userId,
+            windowStartMs      = record.windowStartMs,
+            windowEndMs        = record.windowEndMs,
+            eventCount         = record.count,
+            label              = "error",
+            confidence         = 0.0,
+            inferenceLatencyMs = latency_ms,
+            predictedAtMs      = int(time.time() * 1000),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Optional Kafka helpers (kafka-python; gracefully skipped if unavailable)
+# ---------------------------------------------------------------------------
+
+def _try_produce(records: List[UserEventCount], bootstrap: str, topic: str) -> bool:
+    try:
+        from kafka import KafkaProducer  # type: ignore
+        producer = KafkaProducer(
+            bootstrap_servers=bootstrap,
+            value_serializer=lambda v: json.dumps(asdict(v)).encode(),
+        )
+        for r in records:
+            producer.send(topic, value=r)
+        producer.flush()
+        producer.close()
+        return True
+    except Exception as exc:
+        print(f"[demo] Kafka produce skipped ({exc.__class__.__name__}: {exc})")
+        return False
+
+
+def _try_publish_predictions(
+        preds: List[InferencePrediction], bootstrap: str, topic: str) -> bool:
+    try:
+        from kafka import KafkaProducer  # type: ignore
+        producer = KafkaProducer(
+            bootstrap_servers=bootstrap,
+            value_serializer=lambda v: json.dumps(asdict(v)).encode(),
+        )
+        for p in preds:
+            producer.send(topic, value=p)
+        producer.flush()
+        producer.close()
+        return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+def _print_report(
+        records: List[UserEventCount],
+        predictions: List[InferencePrediction],
+        total_s: float,
+        kafka_ok: bool,
+        model_server_url: str,
+) -> None:
+    label_counts: dict[str, int] = {"low": 0, "medium": 0, "high": 0, "error": 0}
+    latencies: List[int] = []
+    for p in predictions:
+        label_counts[p.label] = label_counts.get(p.label, 0) + 1
+        latencies.append(p.inferenceLatencyMs)
+
+    avg_lat  = sum(latencies) / len(latencies) if latencies else 0
+    p99_lat  = sorted(latencies)[int(len(latencies) * 0.99)] if latencies else 0
+    errors   = label_counts.get("error", 0)
+    sep      = "=" * 70
+
+    print(f"\n{sep}")
+    print("  StreamForge AI — Real-time Inference Pipeline Demo")
+    print(sep)
+    print(f"  Model server  : {model_server_url}")
+    print(f"  Kafka         : {'connected' if kafka_ok else 'offline (demo mode)'}")
+    print(f"  Records in    : {len(records):,}")
+    print(f"  Predictions   : {len(predictions):,}")
+    print()
+    print("  ── Label distribution ────────────────────────────")
+    for label in ("low", "medium", "high", "error"):
+        n   = label_counts.get(label, 0)
+        pct = n / len(predictions) * 100 if predictions else 0
+        bar = "█" * int(pct / 2)
+        print(f"  {label:8s} {n:5,}  ({pct:5.1f}%)  {bar}")
+    print()
+    print("  ── Inference latency ─────────────────────────────")
+    print(f"  avg           : {avg_lat:.1f} ms")
+    print(f"  p99           : {p99_lat} ms")
+    print(f"  errors        : {errors}")
+    print()
+    print(f"  ── Total demo time: {total_s:.2f}s ──")
+    print(sep + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Main demo
+# ---------------------------------------------------------------------------
+
+def run_demo(
+        n_records: int = 100,
+        window_size_s: int = 60,
+        model_server_url: str = "http://localhost:8080/predict",
+        model_timeout_s: float = 2.0,
+        kafka_bootstrap: str = "localhost:9092",
+        source_topic: str = "user.event.counts",
+        sink_topic: str = "user.event.predictions",
+        verbose: bool = False,
+) -> None:
+    t0 = time.perf_counter()
+
+    # Stage 1: Generate synthetic records
+    print(f"\n[demo] Stage 1/3 — generating {n_records} synthetic UserEventCount records …")
+    records = _generate_records(n_records, window_size_s)
+
+    # Stage 2: Optionally produce to Kafka
+    print(f"[demo] Stage 2/3 — publishing to Kafka topic '{source_topic}' …")
+    kafka_ok = _try_produce(records, kafka_bootstrap, source_topic)
+
+    # Stage 3: Call model server for each record
+    print(f"[demo] Stage 3/3 — calling model server ({model_server_url}) …")
+    predictions: List[InferencePrediction] = []
+    for i, rec in enumerate(records):
+        pred = _call_model_server(rec, model_server_url, model_timeout_s)
+        predictions.append(pred)
+        if verbose:
+            print(f"  [{i+1:4d}/{n_records}] userId={pred.userId} "
+                  f"count={pred.eventCount} → {pred.label} "
+                  f"({pred.confidence:.3f}) {pred.inferenceLatencyMs}ms")
+
+    # Optionally write predictions back to Kafka
+    if kafka_ok:
+        _try_publish_predictions(predictions, kafka_bootstrap, sink_topic)
+
+    total_s = time.perf_counter() - t0
+    _print_report(records, predictions, total_s, kafka_ok, model_server_url)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="StreamForge AI real-time inference pipeline demo"
+    )
+    p.add_argument("--records",    type=int,   default=100,
+                   help="Number of synthetic UserEventCount records (default: 100)")
+    p.add_argument("--window",     type=int,   default=60,
+                   help="Window size in seconds (default: 60)")
+    p.add_argument("--verbose",    action="store_true",
+                   help="Print each prediction as it arrives")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    run_demo(
+        n_records        = args.records,
+        window_size_s    = args.window,
+        model_server_url = os.environ.get("MODEL_SERVER_URL",       "http://localhost:8080/predict"),
+        model_timeout_s  = float(os.environ.get("MODEL_SERVER_TIMEOUT_S", "2")),
+        kafka_bootstrap  = os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
+        source_topic     = os.environ.get("KAFKA_SOURCE_TOPIC",      "user.event.counts"),
+        sink_topic       = os.environ.get("KAFKA_SINK_TOPIC",        "user.event.predictions"),
+        verbose          = args.verbose,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/realtime-inference/docker-compose.yml
+++ b/examples/realtime-inference/docker-compose.yml
@@ -1,0 +1,78 @@
+# StreamForge AI — Real-time Inference Pipeline Demo
+#
+# Topology
+# --------
+#   Kafka ──► [InferencePipelineJob (Flink)] ──► model-server ──► Kafka
+#
+# Usage
+# -----
+#   # Standalone (model server + demo runner only, no upstream Flink job):
+#   docker compose up --build
+#
+#   # Full pipeline (extends the CDC → Flink stack):
+#   docker compose \
+#     -f deploy/cdc-flink-minio-demo/docker-compose.yml \
+#     -f examples/realtime-inference/docker-compose.yml \
+#     up
+
+services:
+
+  # ── Kafka (single-node KRaft — no ZooKeeper) ─────────────────────────────
+  kafka:
+    image: apache/kafka:3.7.0
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://:9092,CONTROLLER://:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+    ports:
+      - "9092:9092"
+    healthcheck:
+      test: ["CMD", "kafka-broker-api-versions.sh", "--bootstrap-server", "localhost:9092"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  # ── Model server ──────────────────────────────────────────────────────────
+  model-server:
+    build:
+      context: ../../
+      dockerfile: examples/realtime-inference/Dockerfile
+    environment:
+      MODEL_SERVER_PORT: 8080
+      MODEL_LOW_THRESHOLD: ${MODEL_LOW_THRESHOLD:-5}
+      MODEL_MEDIUM_THRESHOLD: ${MODEL_MEDIUM_THRESHOLD:-20}
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # ── Demo runner (produces synthetic data, calls model server, prints report)
+  demo:
+    build:
+      context: ../../
+      dockerfile: examples/realtime-inference/Dockerfile
+    depends_on:
+      kafka:
+        condition: service_healthy
+      model-server:
+        condition: service_healthy
+    environment:
+      KAFKA_BOOTSTRAP_SERVERS: kafka:9092
+      KAFKA_SOURCE_TOPIC: user.event.counts
+      KAFKA_SINK_TOPIC: user.event.predictions
+      MODEL_SERVER_URL: http://model-server:8080/predict
+      MODEL_SERVER_TIMEOUT_S: "2"
+    command: >
+      python examples/realtime-inference/demo.py
+        --records ${DEMO_RECORDS:-200}
+        --window  ${DEMO_WINDOW_S:-60}
+    restart: "no"

--- a/examples/realtime-inference/model_server.py
+++ b/examples/realtime-inference/model_server.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+StreamForge AI — Model Server
+
+Lightweight FastAPI inference endpoint consumed by InferencePipelineJob.
+
+Endpoint
+--------
+  POST /predict
+    Body : {"userId": str, "count": int, "windowStartMs": int, "windowEndMs": int}
+    Reply: {"label": "low"|"medium"|"high", "confidence": float}
+
+The model is a simple threshold classifier that ships as a stand-in for any
+real serialized model (scikit-learn, ONNX, TorchScript, etc.).  Swap
+_load_model() to load from disk/S3 without changing the serving code.
+
+Usage
+-----
+  pip install fastapi uvicorn
+  python examples/realtime-inference/model_server.py          # port 8080
+  MODEL_SERVER_PORT=9090 python examples/realtime-inference/model_server.py
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import time
+from dataclasses import dataclass
+from typing import Literal
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+# ---------------------------------------------------------------------------
+# Request / response schemas
+# ---------------------------------------------------------------------------
+
+class PredictRequest(BaseModel):
+    userId:        str
+    count:         int
+    windowStartMs: int
+    windowEndMs:   int
+
+
+class PredictResponse(BaseModel):
+    label:      Literal["low", "medium", "high"]
+    confidence: float
+
+
+# ---------------------------------------------------------------------------
+# Model (replace with a real serialized model as needed)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ThresholdModel:
+    """Classifies activity level by event count per window."""
+    low_max:    int   = 5
+    medium_max: int   = 20
+
+    def predict(self, count: int, window_duration_ms: int) -> tuple[str, float]:
+        # Normalise by window length to be rate-based, not count-based
+        window_s     = max(window_duration_ms / 1000, 1)
+        rate_per_min = count / window_s * 60
+
+        if rate_per_min <= self.low_max:
+            label      = "low"
+            # sigmoid-shaped confidence: higher away from threshold
+            raw        = self.low_max - rate_per_min
+            confidence = _sigmoid(raw / self.low_max * 4)
+        elif rate_per_min <= self.medium_max:
+            label      = "medium"
+            mid        = (self.low_max + self.medium_max) / 2
+            confidence = _sigmoid((1 - abs(rate_per_min - mid) / mid) * 4)
+        else:
+            label      = "high"
+            raw        = rate_per_min - self.medium_max
+            confidence = _sigmoid(raw / self.medium_max * 4)
+
+        return label, round(max(0.5, min(1.0, confidence)), 4)
+
+
+def _sigmoid(x: float) -> float:
+    return 1.0 / (1.0 + math.exp(-x))
+
+
+def _load_model() -> ThresholdModel:
+    """Load model from disk/env; returns built-in threshold model as default."""
+    low_max    = int(os.environ.get("MODEL_LOW_THRESHOLD",    "5"))
+    medium_max = int(os.environ.get("MODEL_MEDIUM_THRESHOLD", "20"))
+    return ThresholdModel(low_max=low_max, medium_max=medium_max)
+
+
+# ---------------------------------------------------------------------------
+# App
+# ---------------------------------------------------------------------------
+
+app   = FastAPI(title="StreamForge Model Server", version="1.0.0")
+model = _load_model()
+
+_requests_total = 0
+_errors_total   = 0
+_latency_sum_ms = 0.0
+
+
+@app.post("/predict", response_model=PredictResponse)
+def predict(req: PredictRequest) -> PredictResponse:
+    global _requests_total, _errors_total, _latency_sum_ms
+
+    t0 = time.perf_counter()
+    _requests_total += 1
+
+    window_duration_ms = max(req.windowEndMs - req.windowStartMs, 1)
+    label, confidence  = model.predict(req.count, window_duration_ms)
+
+    _latency_sum_ms += (time.perf_counter() - t0) * 1000
+    return PredictResponse(label=label, confidence=confidence)
+
+
+@app.get("/healthz")
+def healthz() -> dict:
+    return {"status": "ok"}
+
+
+@app.get("/metrics")
+def metrics() -> dict:
+    avg_latency = (_latency_sum_ms / _requests_total) if _requests_total else 0.0
+    return {
+        "requests_total":   _requests_total,
+        "errors_total":     _errors_total,
+        "avg_latency_ms":   round(avg_latency, 3),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    port = int(os.environ.get("MODEL_SERVER_PORT", "8080"))
+    print(f"[model-server] Starting on port {port} (thresholds: "
+          f"low≤{model.low_max} ev/min, medium≤{model.medium_max} ev/min)")
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")

--- a/examples/realtime-inference/requirements.txt
+++ b/examples/realtime-inference/requirements.txt
@@ -1,0 +1,8 @@
+# Real-time Inference Example — Python dependencies
+
+# Model server
+fastapi>=0.111.0
+uvicorn[standard]>=0.29.0
+
+# Optional: Kafka integration in demo.py (gracefully skipped if absent)
+# kafka-python>=2.0.0

--- a/stream-processor/src/main/java/ai/streamforge/processor/InferencePipelineJob.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/InferencePipelineJob.java
@@ -1,0 +1,112 @@
+package ai.streamforge.processor;
+
+import ai.streamforge.processor.deserialization.UserEventCountDeserializationSchema;
+import ai.streamforge.processor.inference.ModelServerAsyncFunction;
+import ai.streamforge.processor.model.InferencePrediction;
+import ai.streamforge.processor.model.UserEventCount;
+import ai.streamforge.processor.serialization.InferencePredictionSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaRecordSerializationSchema;
+import org.apache.flink.connector.kafka.sink.KafkaSink;
+import org.apache.flink.connector.kafka.source.KafkaSource;
+import org.apache.flink.connector.kafka.source.enumerator.initializer.OffsetsInitializer;
+import org.apache.flink.streaming.api.datastream.AsyncDataStream;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Real-time inference pipeline job.
+ *
+ * <p>Reads {@link UserEventCount} records produced by {@link CdcUserEventCountJob}
+ * from a Kafka topic, calls a model server HTTP endpoint for each record via
+ * Flink's async I/O API, and writes the resulting {@link InferencePrediction}
+ * records back to Kafka.
+ *
+ * <pre>
+ *   Kafka (user.event.counts)
+ *        │
+ *        ▼
+ *   [Async HTTP] ──► model-server /predict
+ *        │
+ *        ▼
+ *   Kafka (user.event.predictions)
+ * </pre>
+ *
+ * <p>Configuration via environment variables:
+ * <ul>
+ *   <li>{@code KAFKA_BOOTSTRAP_SERVERS}  — default {@code localhost:9092}</li>
+ *   <li>{@code KAFKA_SOURCE_TOPIC}       — default {@code user.event.counts}</li>
+ *   <li>{@code KAFKA_SINK_TOPIC}         — default {@code user.event.predictions}</li>
+ *   <li>{@code KAFKA_CONSUMER_GROUP}     — default {@code flink-inference-pipeline}</li>
+ *   <li>{@code MODEL_SERVER_URL}         — default {@code http://localhost:8080/predict}</li>
+ *   <li>{@code MODEL_SERVER_TIMEOUT_MS}  — per-request timeout, default {@code 2000}</li>
+ *   <li>{@code ASYNC_MAX_CONCURRENT}     — max in-flight async requests, default {@code 100}</li>
+ *   <li>{@code ASYNC_TIMEOUT_MS}         — Flink async-I/O timeout, default {@code 5000}</li>
+ * </ul>
+ */
+public class InferencePipelineJob {
+
+    private static final Logger LOG = LoggerFactory.getLogger(InferencePipelineJob.class);
+
+    public static void main(String[] args) throws Exception {
+        String bootstrapServers  = env("KAFKA_BOOTSTRAP_SERVERS",  "localhost:9092");
+        String sourceTopic       = env("KAFKA_SOURCE_TOPIC",       "user.event.counts");
+        String sinkTopic         = env("KAFKA_SINK_TOPIC",         "user.event.predictions");
+        String consumerGroup     = env("KAFKA_CONSUMER_GROUP",     "flink-inference-pipeline");
+        String modelServerUrl    = env("MODEL_SERVER_URL",         "http://localhost:8080/predict");
+        long   requestTimeoutMs  = Long.parseLong(env("MODEL_SERVER_TIMEOUT_MS", "2000"));
+        int    maxConcurrent     = Integer.parseInt(env("ASYNC_MAX_CONCURRENT",  "100"));
+        long   asyncTimeoutMs    = Long.parseLong(env("ASYNC_TIMEOUT_MS",        "5000"));
+
+        LOG.info("Starting InferencePipelineJob: source={}, sink={}, modelServer={}",
+                sourceTopic, sinkTopic, modelServerUrl);
+
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.enableCheckpointing(30_000);
+
+        // ── Source: UserEventCount from Kafka ────────────────────────────────
+        KafkaSource<UserEventCount> source = KafkaSource.<UserEventCount>builder()
+                .setBootstrapServers(bootstrapServers)
+                .setTopics(sourceTopic)
+                .setGroupId(consumerGroup)
+                .setStartingOffsets(OffsetsInitializer.earliest())
+                .setValueOnlyDeserializer(new UserEventCountDeserializationSchema())
+                .build();
+
+        DataStream<UserEventCount> counts = env
+                .fromSource(source,
+                        org.apache.flink.api.common.eventtime.WatermarkStrategy.noWatermarks(),
+                        "Kafka: " + sourceTopic);
+
+        // ── Async inference: call model server without blocking Flink threads ─
+        DataStream<InferencePrediction> predictions = AsyncDataStream.unorderedWait(
+                counts,
+                new ModelServerAsyncFunction(modelServerUrl, requestTimeoutMs),
+                asyncTimeoutMs,
+                TimeUnit.MILLISECONDS,
+                maxConcurrent)
+                .name("Async Model Server: " + modelServerUrl);
+
+        // ── Sink: InferencePrediction → Kafka ────────────────────────────────
+        KafkaSink<InferencePrediction> sink = KafkaSink.<InferencePrediction>builder()
+                .setBootstrapServers(bootstrapServers)
+                .setRecordSerializer(
+                        KafkaRecordSerializationSchema.<InferencePrediction>builder()
+                                .setTopic(sinkTopic)
+                                .setValueSerializationSchema(new InferencePredictionSerializationSchema())
+                                .build())
+                .build();
+
+        predictions.sinkTo(sink).name("Kafka Sink: " + sinkTopic);
+
+        env.execute("InferencePipelineJob");
+    }
+
+    private static String env(String name, String defaultValue) {
+        String v = System.getenv(name);
+        return (v != null && !v.isBlank()) ? v : defaultValue;
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/deserialization/UserEventCountDeserializationSchema.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/deserialization/UserEventCountDeserializationSchema.java
@@ -1,0 +1,38 @@
+package ai.streamforge.processor.deserialization;
+
+import ai.streamforge.processor.model.UserEventCount;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+/** Deserializes JSON bytes from the {@code user.event.counts} topic into {@link UserEventCount}. */
+public class UserEventCountDeserializationSchema implements DeserializationSchema<UserEventCount> {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient ObjectMapper objectMapper;
+
+    @Override
+    public void open(InitializationContext context) {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public UserEventCount deserialize(byte[] message) {
+        try {
+            return objectMapper.readValue(message, UserEventCount.class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to deserialize UserEventCount", e);
+        }
+    }
+
+    @Override
+    public boolean isEndOfStream(UserEventCount nextElement) {
+        return false;
+    }
+
+    @Override
+    public TypeInformation<UserEventCount> getProducedType() {
+        return TypeInformation.of(UserEventCount.class);
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/inference/ModelServerAsyncFunction.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/inference/ModelServerAsyncFunction.java
@@ -1,0 +1,143 @@
+package ai.streamforge.processor.inference;
+
+import ai.streamforge.processor.model.InferencePrediction;
+import ai.streamforge.processor.model.UserEventCount;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Histogram;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.streaming.api.functions.async.ResultFuture;
+import org.apache.flink.streaming.api.functions.async.RichAsyncFunction;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Flink async function that calls a model server HTTP endpoint for each
+ * {@link UserEventCount} record and emits an {@link InferencePrediction}.
+ *
+ * <p>Uses Java 11 {@link HttpClient} with non-blocking async dispatch so Flink
+ * task threads are never blocked waiting for the remote call.
+ *
+ * <p>On HTTP error or timeout the record is emitted with label="error" and
+ * confidence=0.0 so the pipeline never stalls.
+ *
+ * <p>Configuration via constructor parameters (environment-variable wiring is
+ * done in {@link ai.streamforge.processor.InferencePipelineJob}):
+ * <ul>
+ *   <li>{@code modelServerUrl} — e.g. {@code http://model-server:8080/predict}</li>
+ *   <li>{@code timeoutMs}      — per-request timeout, default 2000 ms</li>
+ * </ul>
+ */
+public class ModelServerAsyncFunction
+        extends RichAsyncFunction<UserEventCount, InferencePrediction> {
+
+    private static final long serialVersionUID = 1L;
+    private static final Logger LOG = LoggerFactory.getLogger(ModelServerAsyncFunction.class);
+
+    private final String modelServerUrl;
+    private final long   timeoutMs;
+
+    private transient HttpClient   httpClient;
+    private transient ObjectMapper objectMapper;
+    private transient Counter      requestsTotal;
+    private transient Counter      errorsTotal;
+
+    public ModelServerAsyncFunction(String modelServerUrl, long timeoutMs) {
+        this.modelServerUrl = modelServerUrl;
+        this.timeoutMs      = timeoutMs;
+    }
+
+    @Override
+    public void open(Configuration parameters) {
+        httpClient   = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(timeoutMs))
+                .build();
+        objectMapper = new ObjectMapper();
+
+        MetricGroup mg = getRuntimeContext().getMetricGroup().addGroup("model_server");
+        requestsTotal  = mg.counter("requests_total");
+        errorsTotal    = mg.counter("errors_total");
+    }
+
+    @Override
+    public void asyncInvoke(UserEventCount input, ResultFuture<InferencePrediction> resultFuture) {
+        long startNs = System.nanoTime();
+        requestsTotal.inc();
+
+        ObjectNode body = objectMapper.createObjectNode()
+                .put("userId",         input.userId)
+                .put("count",          input.count)
+                .put("windowStartMs",  input.windowStartMs)
+                .put("windowEndMs",    input.windowEndMs);
+
+        HttpRequest request;
+        try {
+            request = HttpRequest.newBuilder()
+                    .uri(URI.create(modelServerUrl))
+                    .timeout(Duration.ofMillis(timeoutMs))
+                    .header("Content-Type", "application/json")
+                    .POST(HttpRequest.BodyPublishers.ofString(objectMapper.writeValueAsString(body)))
+                    .build();
+        } catch (Exception e) {
+            errorsTotal.inc();
+            resultFuture.complete(Collections.singleton(errorPrediction(input, 0)));
+            return;
+        }
+
+        CompletableFuture<HttpResponse<String>> future =
+                httpClient.sendAsync(request, HttpResponse.BodyHandlers.ofString());
+
+        future.whenComplete((response, ex) -> {
+            long latencyMs = (System.nanoTime() - startNs) / 1_000_000;
+            if (ex != null || response.statusCode() != 200) {
+                errorsTotal.inc();
+                LOG.warn("Model server error (latency={}ms, ex={})", latencyMs,
+                        ex != null ? ex.getMessage() : "HTTP " + response.statusCode());
+                resultFuture.complete(Collections.singleton(errorPrediction(input, latencyMs)));
+                return;
+            }
+            try {
+                JsonNode json        = objectMapper.readTree(response.body());
+                String   label       = json.path("label").asText("unknown");
+                double   confidence  = json.path("confidence").asDouble(0.0);
+                resultFuture.complete(Collections.singleton(
+                        new InferencePrediction(
+                                input.userId,
+                                input.windowStartMs,
+                                input.windowEndMs,
+                                input.count,
+                                label,
+                                confidence,
+                                latencyMs)));
+            } catch (Exception parseEx) {
+                errorsTotal.inc();
+                LOG.warn("Failed to parse model server response: {}", parseEx.getMessage());
+                resultFuture.complete(Collections.singleton(errorPrediction(input, latencyMs)));
+            }
+        });
+    }
+
+    @Override
+    public void timeout(UserEventCount input, ResultFuture<InferencePrediction> resultFuture) {
+        errorsTotal.inc();
+        LOG.warn("Model server timed out for userId={}", input.userId);
+        resultFuture.complete(Collections.singleton(errorPrediction(input, timeoutMs)));
+    }
+
+    private InferencePrediction errorPrediction(UserEventCount input, long latencyMs) {
+        return new InferencePrediction(
+                input.userId, input.windowStartMs, input.windowEndMs,
+                input.count, "error", 0.0, latencyMs);
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/model/InferencePrediction.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/model/InferencePrediction.java
@@ -1,0 +1,49 @@
+package ai.streamforge.processor.model;
+
+/** Model server prediction attached to one {@link UserEventCount} window. */
+public class InferencePrediction {
+
+    public String userId;
+    public long   windowStartMs;
+    public long   windowEndMs;
+    public long   eventCount;
+
+    /** Predicted activity label: "low" | "medium" | "high" */
+    public String label;
+
+    /** Model confidence in [0, 1]. */
+    public double confidence;
+
+    /** Wall-clock latency of the model-server round-trip, in milliseconds. */
+    public long inferenceLatencyMs;
+
+    /** Epoch-ms when this prediction was produced. */
+    public long predictedAtMs;
+
+    public InferencePrediction() {}
+
+    public InferencePrediction(
+            String userId,
+            long windowStartMs,
+            long windowEndMs,
+            long eventCount,
+            String label,
+            double confidence,
+            long inferenceLatencyMs) {
+        this.userId             = userId;
+        this.windowStartMs      = windowStartMs;
+        this.windowEndMs        = windowEndMs;
+        this.eventCount         = eventCount;
+        this.label              = label;
+        this.confidence         = confidence;
+        this.inferenceLatencyMs = inferenceLatencyMs;
+        this.predictedAtMs      = System.currentTimeMillis();
+    }
+
+    @Override
+    public String toString() {
+        return "InferencePrediction{userId='" + userId + "', label='" + label
+                + "', confidence=" + String.format("%.3f", confidence)
+                + ", latencyMs=" + inferenceLatencyMs + "}";
+    }
+}

--- a/stream-processor/src/main/java/ai/streamforge/processor/serialization/InferencePredictionSerializationSchema.java
+++ b/stream-processor/src/main/java/ai/streamforge/processor/serialization/InferencePredictionSerializationSchema.java
@@ -1,0 +1,27 @@
+package ai.streamforge.processor.serialization;
+
+import ai.streamforge.processor.model.InferencePrediction;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+
+/** Serializes {@link InferencePrediction} to JSON bytes for the Kafka sink. */
+public class InferencePredictionSerializationSchema implements SerializationSchema<InferencePrediction> {
+
+    private static final long serialVersionUID = 1L;
+
+    private transient ObjectMapper objectMapper;
+
+    @Override
+    public void open(InitializationContext context) {
+        objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public byte[] serialize(InferencePrediction element) {
+        try {
+            return objectMapper.writeValueAsBytes(element);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize InferencePrediction: " + element, e);
+        }
+    }
+}


### PR DESCRIPTION
…mple

Adds an end-to-end example showing how to attach a model server to a Flink streaming pipeline using AsyncDataStream.unorderedWait() so inference never blocks task threads.

Java (stream-processor):
  - InferencePipelineJob — reads UserEventCount from Kafka, fans out up to 100 concurrent HTTP calls via ModelServerAsyncFunction, sinks InferencePrediction records back to Kafka
  - ModelServerAsyncFunction — RichAsyncFunction backed by Java 11 HttpClient; timeouts + HTTP errors emit label="error" and are counted in Flink metrics (model_server.requests_total / errors_total)
  - InferencePrediction POJO + serialization/deserialization schemas

Python (examples/realtime-inference/):
  - model_server.py — FastAPI /predict endpoint with a swappable threshold classifier; exposes /healthz and /metrics
  - demo.py — offline-capable demo: generates synthetic UserEventCount records, calls model server, prints label distribution + latency report
  - docker-compose.yml — Kafka (KRaft) + model-server + demo runner
  - Dockerfile, requirements.txt, README.md